### PR TITLE
chore(release): mark v0.23.1 as released

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1,11 +1,11 @@
 {
-  "latestVersion": "0.23.0",
-  "currentDevelopment": "0.23.1",
+  "latestVersion": "0.23.1",
+  "currentDevelopment": null,
   "releases": [
     {
       "version": "0.23.1",
       "date": "2026-03-12",
-      "status": "unreleased",
+      "status": "released",
       "breaking": false,
       "summary": "Resolve agent model IDs through inference profile mapping before Bedrock invocation",
       "highlights": [


### PR DESCRIPTION
## Summary
Fixes releases.json to correctly mark v0.23.1 as released and update latestVersion.

The `release:publish` step updated this file but the push failed because the release branch had already been merged to main. The tag `v0.23.1` was pushed successfully but the metadata update was lost.

## Changes
- `latestVersion`: `0.23.0` → `0.23.1`
- `currentDevelopment`: `0.23.1` → `null`
- v0.23.1 `status`: `unreleased` → `released`