### PR TITLE
fix(converse): extract text from raw Bedrock multi-agent response JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Pika Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.2] - 2026-03-12
+
+### Fixed
+
+- **Raw Bedrock API response JSON displayed in multi-agent chat output** - Added `extractTextFromRawResponse()` to detect and extract text content from raw Converse API response objects that Bedrock now passes through in multi-agent collaboration chunks. When a collaborator agent uses `AgentCommunication__sendMessage`, Bedrock may send the entire raw response envelope instead of just the text — this fix parses it and extracts the clean content, falling back to the original chunk if parsing fails.
+
+---
+
 ## [0.23.1] - 2026-03-12
 
 ### Fixed

--- a/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
@@ -7,6 +7,14 @@ Complete version history of the Pika Framework.
 
 ---
 
+## [0.23.2] - 2026-03-12
+
+### Fixed
+
+- **Raw Bedrock API response JSON displayed in multi-agent chat output** - Added `extractTextFromRawResponse()` to detect and extract text content from raw Converse API response objects that Bedrock now passes through in multi-agent collaboration chunks. When a collaborator agent uses `AgentCommunication__sendMessage`, Bedrock may send the entire raw response envelope instead of just the text — this fix parses it and extracts the clean content, falling back to the original chunk if parsing fails.
+
+---
+
 ## [0.23.1] - 2026-03-12
 
 ### Fixed

--- a/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
@@ -7,14 +7,20 @@ Stay up to date with the latest Pika Framework releases, new features, and impor
 
 ## Current Version
 
+### What's New in 0.23.2
+
+- **Multi-agent raw response fix** - Chat output no longer displays raw Bedrock Converse API response JSON in multi-agent collaboration scenarios
+  - Detects raw response envelopes from `AgentCommunication__sendMessage` and extracts clean text content
+  - Falls back to original chunk if parsing fails — defensive against future Bedrock API changes
+
+**Latest Stable:** `0.23.2` (March 12, 2026)
+
 ### What's New in 0.23.1
 
 - **Agent model ID resolution** - `resolveModelId()` automatically maps bare model IDs to inference profile IDs before Bedrock invocation
   - Fixes `ValidationException` when agent definitions use bare model IDs (e.g. `anthropic.claude-…`) instead of inference profiles (`us.anthropic.claude-…`)
   - Also resolves to env-overridden inference profile ARNs when configured
   - Applied at all three invocation points: main agent, collaborators, and verification model
-
-**Latest Stable:** `0.23.1` (March 12, 2026)
 
 ### What's New in 0.23.0
 
@@ -580,6 +586,7 @@ When breaking changes are introduced:
 
 | Version | Date        | Type     | Summary                                       |
 | ------- | ----------- | -------- | --------------------------------------------- |
+| 0.23.2  | Mar 12 2026 | Patch    | Fix raw Bedrock API response JSON in multi-agent chat output |
 | 0.23.1  | Mar 12 2026 | Patch    | Resolve agent model IDs through inference profile mapping |
 | 0.23.0  | Mar 12 2026 | Feature  | Server hooks extension point for customUserData transformation |
 | 0.22.1  | Mar 10 2026 | Patch    | Fix external users unable to see chat apps on home page |

--- a/releases.json
+++ b/releases.json
@@ -1,7 +1,18 @@
 {
-  "latestVersion": "0.23.1",
-  "currentDevelopment": null,
+  "latestVersion": "0.23.2",
+  "currentDevelopment": "0.23.2",
   "releases": [
+    {
+      "version": "0.23.2",
+      "date": "2026-03-12",
+      "status": "released",
+      "breaking": false,
+      "summary": "Fix raw Bedrock API response JSON displayed in multi-agent chat output",
+      "highlights": [
+        "Added extractTextFromRawResponse() to detect and extract text from raw Converse API response envelopes in multi-agent chunks",
+        "Defensive fallback to original chunk if parsing fails"
+      ]
+    },
     {
       "version": "0.23.1",
       "date": "2026-03-12",

--- a/services/pika/src/lib/bedrock-agent.ts
+++ b/services/pika/src/lib/bedrock-agent.ts
@@ -133,6 +133,63 @@ export function getBedrockClient(): BedrockRuntimeClient {
     return bedrockClient;
 }
 
+interface ConverseToolUseBlock {
+    toolUse?: {
+        toolUseId?: string;
+        name?: string;
+        input?: { recipient?: string; content?: string };
+    };
+    text?: string;
+}
+
+interface ConverseResponseEnvelope {
+    output?: {
+        message?: {
+            role?: string;
+            content?: ConverseToolUseBlock[];
+        };
+    };
+    stopReason?: string;
+    usage?: Record<string, number>;
+}
+
+/**
+ * Detects raw Bedrock Converse API response objects being passed through in multi-agent
+ * collaboration scenarios (AgentCommunication__sendMessage) and extracts the actual text content.
+ *
+ * When a collaborator agent responds via AgentCommunication__sendMessage, Bedrock may pass
+ * through the entire raw Converse API response as the chunk bytes instead of just the text.
+ */
+export function extractTextFromRawResponse(decodedChunk: string): string {
+    if (!decodedChunk.startsWith('{')) {
+        return decodedChunk;
+    }
+
+    let parsed: ConverseResponseEnvelope;
+    try {
+        parsed = JSON.parse(decodedChunk);
+    } catch {
+        return decodedChunk;
+    }
+
+    const contentBlocks = parsed.output?.message?.content;
+    if (!Array.isArray(contentBlocks)) {
+        return decodedChunk;
+    }
+
+    const extractedParts: string[] = [];
+
+    for (const block of contentBlocks) {
+        if (block.toolUse?.name === 'AgentCommunication__sendMessage' && block.toolUse.input?.content) {
+            extractedParts.push(block.toolUse.input.content);
+        } else if (block.text) {
+            extractedParts.push(block.text);
+        }
+    }
+
+    return extractedParts.length > 0 ? extractedParts.join('\n') : decodedChunk;
+}
+
 async function invokeAgent(cmdInput: InvokeInlineAgentCommandInput, hooks: InvokeAgentHooks, label: string, appliedDirectives?: SemanticDirective[]) {
     let error: unknown;
     let startingTime = Date.now();
@@ -232,10 +289,12 @@ async function invokeAgent(cmdInput: InvokeInlineAgentCommandInput, hooks: Invok
                 });
 
                 if (chunk.chunk?.bytes) {
-                    const decodedChunk = new TextDecoder().decode(chunk.chunk.bytes);
+                    const rawChunk = new TextDecoder().decode(chunk.chunk.bytes);
+                    const decodedChunk = extractTextFromRawResponse(rawChunk);
                     console.log(label, `Chunk ${chunkCount} decoded:`, {
                         length: decodedChunk.length,
-                        preview: decodedChunk.substring(0, 100)
+                        preview: decodedChunk.substring(0, 100),
+                        wasExtracted: rawChunk !== decodedChunk
                     });
                     responseMsg += decodedChunk;
 

--- a/services/pika/test/lib/extract-text-from-raw-response.test.ts
+++ b/services/pika/test/lib/extract-text-from-raw-response.test.ts
@@ -1,0 +1,172 @@
+import { extractTextFromRawResponse } from '../../src/lib/bedrock-agent';
+
+describe('extractTextFromRawResponse', () => {
+    it('returns plain text chunks unchanged', () => {
+        const plainText = 'Hello, how can I help you today?';
+        expect(extractTextFromRawResponse(plainText)).toBe(plainText);
+    });
+
+    it('returns markdown content unchanged', () => {
+        const markdown = '## Here are some suggestions\n\n- Option A\n- Option B';
+        expect(extractTextFromRawResponse(markdown)).toBe(markdown);
+    });
+
+    it('returns empty string unchanged', () => {
+        expect(extractTextFromRawResponse('')).toBe('');
+    });
+
+    it('extracts text from AgentCommunication__sendMessage tool use', () => {
+        const rawResponse = JSON.stringify({
+            output: {
+                message: {
+                    role: 'assistant',
+                    content: [
+                        {
+                            text: null,
+                            toolUse: {
+                                toolUseId: 'tooluse_abc123',
+                                name: 'AgentCommunication__sendMessage',
+                                input: {
+                                    recipient: 'User',
+                                    content: 'Here is the formatted response from the collaborator agent.'
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            stopReason: 'tool_use',
+            usage: { inputTokens: 6408, outputTokens: 215 }
+        });
+
+        expect(extractTextFromRawResponse(rawResponse)).toBe(
+            'Here is the formatted response from the collaborator agent.'
+        );
+    });
+
+    it('extracts text from plain text content blocks', () => {
+        const rawResponse = JSON.stringify({
+            output: {
+                message: {
+                    role: 'assistant',
+                    content: [{ text: 'Direct text response from the model.' }]
+                }
+            },
+            stopReason: 'end_turn',
+            usage: { inputTokens: 100, outputTokens: 20 }
+        });
+
+        expect(extractTextFromRawResponse(rawResponse)).toBe('Direct text response from the model.');
+    });
+
+    it('joins multiple content blocks with newlines', () => {
+        const rawResponse = JSON.stringify({
+            output: {
+                message: {
+                    role: 'assistant',
+                    content: [
+                        { text: 'First part.' },
+                        {
+                            toolUse: {
+                                toolUseId: 'tooluse_xyz',
+                                name: 'AgentCommunication__sendMessage',
+                                input: { recipient: 'User', content: 'Second part from collaborator.' }
+                            }
+                        }
+                    ]
+                }
+            },
+            stopReason: 'tool_use',
+            usage: { inputTokens: 500, outputTokens: 100 }
+        });
+
+        expect(extractTextFromRawResponse(rawResponse)).toBe('First part.\nSecond part from collaborator.');
+    });
+
+    it('returns original chunk when JSON has no recognizable content blocks', () => {
+        const rawResponse = JSON.stringify({
+            output: {
+                message: {
+                    role: 'assistant',
+                    content: [{ image: { format: 'png', source: {} } }]
+                }
+            },
+            stopReason: 'end_turn',
+            usage: { inputTokens: 100, outputTokens: 50 }
+        });
+
+        expect(extractTextFromRawResponse(rawResponse)).toBe(rawResponse);
+    });
+
+    it('returns original chunk for non-Converse JSON (no output.message.content)', () => {
+        const otherJson = JSON.stringify({ key: 'value', nested: { data: true } });
+        expect(extractTextFromRawResponse(otherJson)).toBe(otherJson);
+    });
+
+    it('returns original chunk for malformed JSON starting with {', () => {
+        const malformed = '{"output":{"message": broken json here';
+        expect(extractTextFromRawResponse(malformed)).toBe(malformed);
+    });
+
+    it('handles content blocks with null text fields gracefully', () => {
+        const rawResponse = JSON.stringify({
+            output: {
+                message: {
+                    role: 'assistant',
+                    content: [
+                        {
+                            text: null,
+                            toolUse: {
+                                toolUseId: 'tooluse_abc',
+                                name: 'AgentCommunication__sendMessage',
+                                input: { recipient: 'User', content: 'The actual message.' }
+                            }
+                        }
+                    ]
+                }
+            },
+            stopReason: 'tool_use',
+            usage: { inputTokens: 200, outputTokens: 50 }
+        });
+
+        expect(extractTextFromRawResponse(rawResponse)).toBe('The actual message.');
+    });
+
+    it('ignores tool use blocks that are not AgentCommunication__sendMessage', () => {
+        const rawResponse = JSON.stringify({
+            output: {
+                message: {
+                    role: 'assistant',
+                    content: [
+                        {
+                            toolUse: {
+                                toolUseId: 'tooluse_abc',
+                                name: 'SomeOtherTool__doSomething',
+                                input: { data: 'not a message' }
+                            }
+                        },
+                        { text: 'Visible text.' }
+                    ]
+                }
+            },
+            stopReason: 'tool_use',
+            usage: { inputTokens: 300, outputTokens: 80 }
+        });
+
+        expect(extractTextFromRawResponse(rawResponse)).toBe('Visible text.');
+    });
+
+    it('returns original chunk when content is not an array', () => {
+        const rawResponse = JSON.stringify({
+            output: {
+                message: {
+                    role: 'assistant',
+                    content: 'just a string'
+                }
+            },
+            stopReason: 'end_turn'
+        });
+
+        expect(extractTextFromRawResponse(rawResponse)).toBe(rawResponse);
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes raw Bedrock Converse API response JSON being displayed in chat output during multi-agent collaboration scenarios
- Adds `extractTextFromRawResponse()` helper that detects raw response envelopes and extracts the actual text content from `AgentCommunication__sendMessage` tool use blocks or plain text content blocks
- Falls back to original chunk if parsing fails — defensive against future Bedrock API changes
- Release notes for v0.23.2

## Changes Made

- `services/pika/src/lib/bedrock-agent.ts` — Added typed `ConverseResponseEnvelope` interfaces, `extractTextFromRawResponse()` function, and wired it into the chunk processing loop
- `services/pika/test/lib/extract-text-from-raw-response.test.ts` — 12 unit tests covering normal text passthrough, raw response extraction, multiple content blocks, malformed JSON, and edge cases
- Release docs: `CHANGELOG.md`, `releases.json`, `changelog.mdoc`, `index.mdoc`

## Test Plan

- [x] All 12 unit tests pass locally
- [x] Validated in ai-bot test environment (ai-bot PR #95)
- [ ] Verify non-collaborator (single-agent) messages are unaffected

## Jira

https://chb.atlassian.net/browse/ES-2938