### PR TITLE
feat(converse): port ai-bot weekly changes — collaborator directives, hook hardening, userType/roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the Pika Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0] - 2026-03-30
+
+### Added
+
+- **Semantic directive injection for collaborator agents** - Collaborator agents now receive runtime-resolved semantic directives alongside the top-level agent. Directives are resolved in parallel using `Promise.allSettled` (one failure doesn't block others) and injected into each collaborator's instruction within an `<additional-instructions>` XML block. A 20K-char size budget with relevance-ranked truncation prevents context window flooding. Per-collaborator directive traces are emitted for admin debugging. [#140]
+
+### Changed
+
+- **Relevance-ordered directive selection** - The LLM prompt for selecting applicable directives now requests IDs ordered from most relevant to least relevant, enabling budget-aware truncation to drop the least important directives first. [#140]
+
+### Fixed
+
+- **Timer leak in transformCustomUserData hook** - The `setTimeout` used for the 5-second hook timeout is now captured and cleared in a `finally` block, preventing a resource leak when the hook resolves before the timer fires. Also removed a dead `if (transformCustomUserData)` guard (the function is a static import, always truthy) and switched from `||` to `??` (nullish coalescing) so falsy-but-valid values like `0`, `""`, or `false` are preserved. [#140]
+- **userType and roles not persisted in DynamoDB** - `updateUser()` now includes `userType` and `roles` in the DynamoDB update expression, so auth-provider values are written back on login instead of silently dropped. Fixes a bug where users with missing `userType` would be defaulted to `external-user` and lose access to internal-only resources. [#140]
+
+---
+
 ## [0.23.2] - 2026-03-12
 
 ### Fixed

--- a/apps/pika-chat/src/routes/(auth)/api/message/+server.ts
+++ b/apps/pika-chat/src/routes/(auth)/api/message/+server.ts
@@ -49,31 +49,33 @@ export const POST: RequestHandler = async ({ request, locals }) => {
         }
 
         //TODO: what do we do if an internal user changes the custom data during a chat session?  Do we care?  Will it break anything downstream?
-        const rawCustomUserData = user.overrideData?.[params.chatAppId] || user.customData;
+        const rawCustomUserData = user.overrideData?.[params.chatAppId] ?? user.customData;
 
         // Allow consumer to transform customUserData before it reaches the agent
         let resolvedCustomUserData = rawCustomUserData;
-        if (transformCustomUserData) {
-            try {
-                const hookResult = await Promise.race([
-                    transformCustomUserData(rawCustomUserData, {
-                        userId: user.userId,
-                        chatAppId: params.chatAppId
-                    }),
-                    new Promise<never>((_, reject) =>
-                        setTimeout(() => reject(new Error(`transformCustomUserData timed out after ${SERVER_HOOK_TIMEOUT_MS}ms`)), SERVER_HOOK_TIMEOUT_MS)
-                    )
-                ]);
+        let timer: ReturnType<typeof setTimeout>;
+        const timeout = new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error(`transformCustomUserData timed out after ${SERVER_HOOK_TIMEOUT_MS}ms`)), SERVER_HOOK_TIMEOUT_MS);
+        });
+        try {
+            const hookResult = await Promise.race([
+                transformCustomUserData(rawCustomUserData, {
+                    userId: user.userId,
+                    chatAppId: params.chatAppId
+                }),
+                timeout
+            ]);
 
-                // Guard against hooks that accidentally return undefined when data existed
-                if (hookResult === undefined && rawCustomUserData !== undefined) {
-                    console.warn('[server-hooks] transformCustomUserData returned undefined; using original data');
-                } else {
-                    resolvedCustomUserData = hookResult;
-                }
-            } catch (e) {
-                console.warn('[server-hooks] transformCustomUserData threw an error, falling back to original data:', e instanceof Error ? e.message : String(e));
+            // Guard against hooks that accidentally return undefined when data existed
+            if (hookResult === undefined && rawCustomUserData !== undefined) {
+                console.warn('[server-hooks] transformCustomUserData returned undefined; using original data');
+            } else {
+                resolvedCustomUserData = hookResult;
             }
+        } catch (e) {
+            console.warn('[server-hooks] transformCustomUserData threw an error, falling back to original data:', e instanceof Error ? e.message : String(e));
+        } finally {
+            clearTimeout(timer!);
         }
 
         const simpleUser: SimpleAuthenticatedUser<typeof user.customData> = {

--- a/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
@@ -7,6 +7,23 @@ Complete version history of the Pika Framework.
 
 ---
 
+## [0.24.0] - 2026-03-30
+
+### Added
+
+- **Semantic directive injection for collaborator agents** - Collaborator agents now receive runtime-resolved semantic directives alongside the top-level agent. Directives are resolved in parallel using `Promise.allSettled` (one failure doesn't block others) and injected into each collaborator's instruction within an `<additional-instructions>` XML block. A 20K-char size budget with relevance-ranked truncation prevents context window flooding. Per-collaborator directive traces are emitted for admin debugging. [#140]
+
+### Changed
+
+- **Relevance-ordered directive selection** - The LLM prompt for selecting applicable directives now requests IDs ordered from most relevant to least relevant, enabling budget-aware truncation to drop the least important directives first. [#140]
+
+### Fixed
+
+- **Timer leak in transformCustomUserData hook** - The `setTimeout` used for the 5-second hook timeout is now captured and cleared in a `finally` block, preventing a resource leak when the hook resolves before the timer fires. Also removed a dead `if (transformCustomUserData)` guard (the function is a static import, always truthy) and switched from `||` to `??` (nullish coalescing) so falsy-but-valid values like `0`, `""`, or `false` are preserved. [#140]
+- **userType and roles not persisted in DynamoDB** - `updateUser()` now includes `userType` and `roles` in the DynamoDB update expression, so auth-provider values are written back on login instead of silently dropped. Fixes a bug where users with missing `userType` would be defaulted to `external-user` and lose access to internal-only resources. [#140]
+
+---
+
 ## [0.23.2] - 2026-03-12
 
 ### Fixed

--- a/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
@@ -7,13 +7,23 @@ Stay up to date with the latest Pika Framework releases, new features, and impor
 
 ## Current Version
 
+### What's New in 0.24.0
+
+- **Semantic directive injection for collaborator agents** - Collaborators now receive their own runtime-resolved directives, not just the top-level agent
+  - Directives resolved in parallel using `Promise.allSettled` — one failure doesn't block others
+  - Injected into collaborator instruction via `<additional-instructions>` XML block with 20K-char size budget
+  - Relevance-ranked truncation drops least-important directives first when budget is exceeded
+  - Per-collaborator directive traces emitted for admin debugging
+- **Server hook hardening** - Timer leak fix, dead guard removal, and `??` nullish coalescing for `transformCustomUserData`
+- **userType and roles persistence** - `updateUser()` now writes `userType` and `roles` to DynamoDB, fixing silent data loss on login
+
+**Latest Stable:** `0.24.0` (March 30, 2026)
+
 ### What's New in 0.23.2
 
 - **Multi-agent raw response fix** - Chat output no longer displays raw Bedrock Converse API response JSON in multi-agent collaboration scenarios
   - Detects raw response envelopes from `AgentCommunication__sendMessage` and extracts clean text content
   - Falls back to original chunk if parsing fails — defensive against future Bedrock API changes
-
-**Latest Stable:** `0.23.2` (March 12, 2026)
 
 ### What's New in 0.23.1
 
@@ -586,6 +596,7 @@ When breaking changes are introduced:
 
 | Version | Date        | Type     | Summary                                       |
 | ------- | ----------- | -------- | --------------------------------------------- |
+| 0.24.0  | Mar 30 2026 | Feature  | Collaborator directive injection, server hook hardening, userType/roles persistence |
 | 0.23.2  | Mar 12 2026 | Patch    | Fix raw Bedrock API response JSON in multi-agent chat output |
 | 0.23.1  | Mar 12 2026 | Patch    | Resolve agent model IDs through inference profile mapping |
 | 0.23.0  | Mar 12 2026 | Feature  | Server hooks extension point for customUserData transformation |

--- a/releases.json
+++ b/releases.json
@@ -1,7 +1,20 @@
 {
-  "latestVersion": "0.23.2",
-  "currentDevelopment": "0.23.2",
+  "latestVersion": "0.24.0",
+  "currentDevelopment": "0.24.0",
   "releases": [
+    {
+      "version": "0.24.0",
+      "date": "2026-03-30",
+      "status": "released",
+      "breaking": false,
+      "summary": "Collaborator directive injection, server hook hardening, userType/roles persistence",
+      "highlights": [
+        "Semantic directives now resolved and injected for collaborator agents in parallel with top-level agent",
+        "Budget-aware directive truncation with relevance ranking for collaborator instructions",
+        "Timer leak fix and nullish coalescing in transformCustomUserData hook",
+        "updateUser() now persists userType and roles to DynamoDB"
+      ]
+    },
     {
       "version": "0.23.2",
       "date": "2026-03-12",

--- a/services/pika/src/lambda/converse/index.ts
+++ b/services/pika/src/lambda/converse/index.ts
@@ -2,6 +2,7 @@ import { type ConversationHistory, ConversationRole } from '@aws-sdk/client-bedr
 import { LRUCache } from 'lru-cache';
 import type {
     AgentAndTools,
+    AgentDefinition,
     ChatAppComponentConfig,
     ChatAppOverridableFeaturesForConverseFn,
     ChatMessage,
@@ -16,6 +17,7 @@ import type {
     InvocationScopes,
     LLMContextItem,
     RecordOrUndef,
+    SemanticDirective,
     SentContextRecord,
     SimpleAuthenticatedUser,
     TagDefinition,
@@ -356,6 +358,7 @@ export const handler = enhancedStreamifyResponse(
                 features,
                 scopes,
                 invocationMode,
+                entityValue,
                 converseRequest.files,
                 converseRequest.chatAppComponentConfig,
                 converseRequest.llmContextItems
@@ -570,6 +573,7 @@ async function converse(
     features: ChatAppOverridableFeaturesForConverseFn,
     scopes: InvocationScopes,
     mode: ConverseInvocationMode,
+    entityValue?: string,
     files?: ChatMessageFile[],
     chatAppComponentConfig?: ChatAppComponentConfig,
     llmContextItems?: LLMContextItem[]
@@ -689,9 +693,62 @@ async function converse(
         }
     }
 
-    const additionalUserPromptInstructions = features.instructionAugmentation?.enabled
-        ? await getAdditionalUserPromptInstructions(scopes, message)
-        : { instructions: '', appliedDirectives: [] };
+    // Resolve directives for top-level agent AND all collaborators in parallel.
+    // Uses Promise.allSettled so a single failure doesn't prevent other directives from resolving.
+    const emptyDirectiveResult = { instructions: '', appliedDirectives: [] as SemanticDirective[] };
+    let additionalUserPromptInstructions = emptyDirectiveResult;
+    let collaboratorDirectives = new Map<string, { instructions: string; appliedDirectives: SemanticDirective[] }>();
+
+    if (features.instructionAugmentation?.enabled) {
+        const collaborators = agentAndTools.collaborators ?? [];
+
+        const buildCollaboratorScopes = (collab: AgentDefinition): InvocationScopes => {
+            // NOTE: chatapp scope is NOT included — it belongs to the top-level invocation only
+            const collabScopes: InvocationScopes = {
+                ...(collab.agentId ? { agent: [collab.agentId] } : {}),
+                ...(collab.toolIds?.length ? { tool: collab.toolIds } : {}),
+                ...(entityValue ? { entity: [entityValue] } : {})
+            };
+            if (collab.agentId && entityValue) {
+                collabScopes['agent-entity'] = [{ agent: collab.agentId, entity: entityValue }];
+            }
+            return collabScopes;
+        };
+
+        const results = await Promise.allSettled([
+            getAdditionalUserPromptInstructions(scopes, message),
+            ...collaborators.map((collab) =>
+                getAdditionalUserPromptInstructions(buildCollaboratorScopes(collab), message).then((result) => ({ agentId: collab.agentId, ...result }))
+            )
+        ]);
+
+        // First result is the top-level agent
+        if (results[0].status === 'fulfilled') {
+            additionalUserPromptInstructions = results[0].value;
+        } else {
+            console.warn('[instruction-augmentation] Top-level directive resolution failed:', results[0].reason);
+        }
+
+        // Remaining results are collaborators
+        for (let i = 1; i < results.length; i++) {
+            const result = results[i];
+            if (result.status === 'fulfilled') {
+                const { agentId, instructions, appliedDirectives } = result.value as { agentId: string; instructions: string; appliedDirectives: SemanticDirective[] };
+                if (appliedDirectives.length > 0) {
+                    collaboratorDirectives.set(agentId, { instructions, appliedDirectives });
+                }
+            } else {
+                console.warn(`[instruction-augmentation] Collaborator directive resolution failed for index ${i}:`, result.reason);
+            }
+        }
+
+        if (collaboratorDirectives.size > 0) {
+            console.log(
+                '[instruction-augmentation] Collaborator directives resolved:',
+                Object.fromEntries([...collaboratorDirectives.entries()].map(([id, d]) => [id, d.appliedDirectives.map((a) => a.id)]))
+            );
+        }
+    }
 
     // Filter and format LLM context items if provided
     let contextStr = '';
@@ -1045,7 +1102,8 @@ ${contextBlocks}
         memoryFeature,
         process.env.POST_PROCESSOR_FUNCTION_ARN,
         conversationHistory,
-        additionalUserPromptInstructions.appliedDirectives
+        additionalUserPromptInstructions.appliedDirectives,
+        collaboratorDirectives
     );
     // console.log('[STREAM-TIMING] Agent streaming complete (invokeAgent returned)', {
     //     elapsed: Date.now() - startTime,

--- a/services/pika/src/lib/bedrock-agent.ts
+++ b/services/pika/src/lib/bedrock-agent.ts
@@ -68,6 +68,11 @@ import { gzipAndBase64EncodeString } from 'pika-shared/util/server-utils';
 const bedrockAgentClient = new BedrockAgentRuntimeClient({ region: getRegion() });
 const bedrockClient = new BedrockRuntimeClient({ region: getRegion() });
 
+/** Soft size budget (chars) for collaborator instruction including injected directives. No hard API limit exists — this prevents flooding the collaborator's context window. */
+const MAX_COLLABORATOR_DIRECTIVE_SIZE = 20_000;
+/** Approximate overhead (chars) for the `<additional-instructions>` XML wrapper around injected directive text. */
+const DIRECTIVE_XML_WRAPPER_OVERHEAD = 50;
+
 // This is a map of toolId to local endpoint
 let localActionGroupEndpoints: Record<string, string> = {};
 if (process.env.LOCAL_TOOLS != null) {
@@ -817,6 +822,62 @@ function processInlineTool(tool: InlineToolDefinition, toolContext: Record<strin
  * @param userId The user id of the user who is sending the message.
  * @param messageId The message id of the user's message.
  * @param questionFromUser The question from the user with optional instructions prepended to ask the agent.
+ * Appends runtime-resolved directives to a collaborator's base instruction, respecting a size budget.
+ * Directives are assumed to be ranked by relevance (most relevant first). Once a directive would
+ * exceed the budget, it and all remaining (less relevant) directives are dropped.
+ */
+function buildCollaboratorInstructionWithDirectives(
+    baseInstruction: string,
+    agentId: string,
+    collaboratorDirectives?: Map<string, { instructions: string; appliedDirectives: SemanticDirective[] }>
+): string {
+    const directiveResult = collaboratorDirectives?.get(agentId);
+    if (!directiveResult || directiveResult.appliedDirectives.length === 0) {
+        return baseInstruction;
+    }
+
+    const budget = MAX_COLLABORATOR_DIRECTIVE_SIZE - baseInstruction.length - DIRECTIVE_XML_WRAPPER_OVERHEAD;
+    if (budget <= 0) {
+        console.warn(`[instruction-augmentation] No budget remaining for collaborator ${agentId} directives (base instruction: ${baseInstruction.length} chars)`);
+        return baseInstruction;
+    }
+
+    let directiveText = '';
+    const applied: SemanticDirective[] = [];
+    const dropped: string[] = [];
+
+    for (let i = 0; i < directiveResult.appliedDirectives.length; i++) {
+        const directive = directiveResult.appliedDirectives[i];
+        const separator = directiveText.length > 0 ? '\n' : '';
+        if (directiveText.length + separator.length + directive.instructions.length > budget) {
+            // Directives are ranked by relevance — all remaining are less relevant, stop here
+            for (let j = i; j < directiveResult.appliedDirectives.length; j++) {
+                dropped.push(directiveResult.appliedDirectives[j].id);
+            }
+            break;
+        }
+        directiveText += separator + directive.instructions;
+        applied.push(directive);
+    }
+
+    if (dropped.length > 0) {
+        console.warn(`[instruction-augmentation] Dropped ${dropped.length} directives for collaborator ${agentId} due to size budget (${budget} chars): ${dropped.join(', ')}`);
+    }
+
+    if (directiveText.length === 0) {
+        return baseInstruction;
+    }
+
+    console.log(`[instruction-augmentation] Injected ${applied.length} directives (${directiveText.length} chars) into collaborator ${agentId}`);
+    return baseInstruction + `\n<additional-instructions>\n${directiveText}\n</additional-instructions>`;
+}
+
+/**
+ * Invokes the Bedrock Inline Agent to generate a response to the user's message.
+ * @param chatSession The chat session to invoke the agent on.
+ * @param userId The user id of the user who is sending the message.
+ * @param messageId The message id of the user's message.
+ * @param questionFromUser The question from the user with optional instructions prepended to ask the agent.
  * @param responseStream The response stream to write the agent's response to.
  * @param conversationHistory The conversation history to reattach to the session if any.
  * @returns The chat message with the agent's response and the usage statistics. Note
@@ -835,7 +896,9 @@ export async function invokeAgentToGetAnswer(
     agentPostProcessorFnArn?: string,
     conversationHistory?: ConversationHistory,
     // The semantic directives that were applied to the prompt so we can add to trace to make it easier to debug
-    appliedDirectives?: SemanticDirective[]
+    appliedDirectives?: SemanticDirective[],
+    // Per-collaborator directives resolved at runtime, keyed by collaborator agentId
+    collaboratorDirectives?: Map<string, { instructions: string; appliedDirectives: SemanticDirective[] }>
 ): Promise<ChatMessageForCreate> {
     console.log('=== INVOKE AGENT START ===');
     console.log('invokeAgentToGetAnswer called with:', {
@@ -1036,14 +1099,21 @@ export async function invokeAgentToGetAnswer(
         },
         actionGroups: toolContexts.map((context) => context.getActionGroups(agentAndTools.agent.toolIds)).flat(),
         collaborators: agentAndTools.collaborators?.map((collaborator) => {
+            const baseInstruction = [
+                collaborator.basePrompt,
+                ...toolContexts.map((context) => context.getInstructions?.(collaborator.toolIds ?? [])).filter((a) => a != null),
+                sessionContextBlock
+            ]
+                .filter((a) => a != null)
+                .join('\n');
+
+            // Inject runtime-resolved directives for this collaborator (if any)
+            const instruction = buildCollaboratorInstructionWithDirectives(baseInstruction, collaborator.agentId, collaboratorDirectives);
+
             let col: Collaborator = {
                 agentName: collaborator.agentId,
-                instruction: [
-                    collaborator.basePrompt,
-                    ...toolContexts.map((context) => context.getInstructions?.(collaborator.toolIds ?? [])).filter((a) => a != null),
-                    sessionContextBlock
-                ].filter((a) => a != null).join('\n'),
-                agentCollaboration: collaborator.agentCollaboration ?? (collaborator.collaborators?.length ? AgentCollaboration.SUPERVISOR : AgentCollaboration.DISABLED), // (collaborator.collaborators?.length ? AgentCollaboration.SUPERVISOR : AgentCollaboration.DISABLED),//?? (collaborator.collaboratorConfigurations?.length ? AgentCollaboration.SUPERVISOR : AgentCollaboration.DISABLED), (collaborator.collaboratorConfigurations?.length ? AgentCollaboration.SUPERVISOR : AgentCollaboration.DISABLED),
+                instruction,
+                agentCollaboration: collaborator.agentCollaboration ?? (collaborator.collaborators?.length ? AgentCollaboration.SUPERVISOR : AgentCollaboration.DISABLED),
                 foundationModel: resolveModelId(collaborator.foundationModel ?? agentAndTools.agent.foundationModel ?? DEFAULT_ANTHROPIC_MODEL),
                 actionGroups: toolContexts.map((context) => context.getActionGroups(collaborator.toolIds ?? [])).flat(),
                 knowledgeBases: collaborator.knowledgeBases?.map(toKnowledgeBase) ?? [],
@@ -1229,6 +1299,29 @@ export async function invokeAgentToGetAnswer(
                 });
             });
         });
+        // Emit per-collaborator directive traces for debugging (admin only on frontend)
+        if (collaboratorDirectives && collaboratorDirectives.size > 0) {
+            for (const [agentId, result] of collaboratorDirectives) {
+                hooks.onTrace({
+                    orchestrationTrace: {
+                        rationale: {
+                            traceId: `semantic-directives-collaborator-${agentId}`,
+                            text: JSON.stringify({
+                                type: 'semantic-directives-collaborator',
+                                collaboratorAgentId: agentId,
+                                directives: result.appliedDirectives.map((d) => ({
+                                    scope: d.scope,
+                                    id: d.id,
+                                    description: d.description,
+                                    instructions: d.instructions
+                                }))
+                            })
+                        }
+                    }
+                });
+            }
+        }
+
         let mainResponse = await invokeAgent(cmdInput, hooks, 'MAIN:', appliedDirectives);
         // console.log('[STREAM-TIMING] invokeAgent returned (streaming complete)', {
         //     elapsed: Date.now() - startingTime,

--- a/services/pika/src/lib/chat-ddb.ts
+++ b/services/pika/src/lib/chat-ddb.ts
@@ -244,6 +244,16 @@ export async function updateUser(user: ChatUser<RecordOrUndef>): Promise<ChatUse
         expressionAttributeNames['#lastName'] = 'last_name';
         expressionAttributeValues[':lastName'] = user.lastName;
     }
+    if (user.userType !== undefined) {
+        updateExpressions.push('#userType = :userType');
+        expressionAttributeNames['#userType'] = 'user_type';
+        expressionAttributeValues[':userType'] = user.userType;
+    }
+    if (user.roles !== undefined) {
+        updateExpressions.push('#roles = :roles');
+        expressionAttributeNames['#roles'] = 'roles';
+        expressionAttributeValues[':roles'] = user.roles;
+    }
     if (user.features !== undefined) {
         updateExpressions.push('#features = :features');
         expressionAttributeNames['#features'] = 'features';

--- a/services/pika/src/lib/instruction-augmentation.ts
+++ b/services/pika/src/lib/instruction-augmentation.ts
@@ -43,7 +43,7 @@ export async function getAdditionalUserPromptInstructions(
 
     const prompt = `Given this user query determine if any of the additional instructions need to be applied.
 
-Return only the ids that should be added as a json array inside an <answer></answer> tag.  If no instructions apply return an empty array []
+Return only the ids that should be added as a json array inside an <answer></answer> tag, ordered from most relevant to least relevant.  If no instructions apply return an empty array []
 Do not include any other text or reasoning.  Just the json array inside the <answer></answer> tag.
 <instructions>
 ${directivesString}


### PR DESCRIPTION
## Summary

Port generalizable changes from ai-bot PRs #96, #97, and #99 back to the Pika framework (v0.24.0):

- **Collaborator directive injection** (ai-bot #96) — Resolve and inject semantic directives for collaborator agents in parallel with the top-level agent. Budget-aware truncation, relevance ordering, and per-collaborator trace emission.
- **Server hook hardening** (ai-bot #97) — Fix timer leak in `transformCustomUserData`, remove dead guard, use `??` instead of `||` for `rawCustomUserData`.
- **userType/roles persistence** (ai-bot #99) — Add `userType` and `roles` to `updateUser()` DynamoDB update expression so auth-provider values are written back on login.

## Changes Made

- `services/pika/src/lambda/converse/index.ts` — Parallel collaborator directive resolution with `Promise.allSettled`, `entityValue` threading, `buildCollaboratorScopes` helper
- `services/pika/src/lib/bedrock-agent.ts` — `buildCollaboratorInstructionWithDirectives()` with 20K-char budget, `collaboratorDirectives` parameter, trace emission
- `services/pika/src/lib/instruction-augmentation.ts` — Relevance-ordered directive selection prompt
- `apps/pika-chat/src/routes/(auth)/api/message/+server.ts` — Timer leak fix, dead guard removal, nullish coalescing
- `services/pika/src/lib/chat-ddb.ts` — `userType` and `roles` in `updateUser()` DDB expression

## Task Reference

- Jira: https://chb.atlassian.net/browse/ES-2947
- Task: ES-2947
- ai-bot PRs: #96, #97, #99

## Testing

- `pnpm --filter @pika/service build` — clean
- `pnpm --filter @pika/service test` — all unit tests pass (integration tests skipped, require AWS connectivity)

## Release

- Release notes for v0.24.0 included
- Tag `v0.24.0` created and pushed