### PR TITLE
fix(strands): raise max_tokens to 64K + add MaxTokensReachedException handler (v0.25.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Pika Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.2] - 2026-05-04
+
+### Changed
+
+- **Strands converse Lambda `max_tokens` raised to 64000** - The hardcoded `max_tokens=4096` in both the main agent and collaborator `BedrockModel` configurations in `services/pika/src/lambda/converse-strands/handler.py` was leftover from older Claude defaults. Claude 4.5 Sonnet's actual maximum output is 64K, and the framework now uses the model's real capacity. Long-form responses (detailed explanations, code generation, multi-step plans) that previously truncated at ~3KB now stream through cleanly. [#144]
+
+### Fixed
+
+- **Graceful handling of `MaxTokensReachedException`** - The Strands converse Lambda now catches `MaxTokensReachedException` from the Strands SDK explicitly and emits a user-facing message ("your request required more processing than I can handle in a single response. Try breaking it into smaller steps or simplifying your request.") instead of falling through to the generic "I encountered an error" handler. Users get an actionable suggestion rather than a generic failure. [#144]
+
+---
+
 ## [0.25.1] - 2026-05-04
 
 ### Added

--- a/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
@@ -7,6 +7,18 @@ Complete version history of the Pika Framework.
 
 ---
 
+## [0.25.2] - 2026-05-04
+
+### Changed
+
+- **Strands converse Lambda `max_tokens` raised to 64000** - The hardcoded `max_tokens=4096` in both the main agent and collaborator `BedrockModel` configurations in `services/pika/src/lambda/converse-strands/handler.py` was leftover from older Claude defaults. Claude 4.5 Sonnet's actual maximum output is 64K, and the framework now uses the model's real capacity. Long-form responses (detailed explanations, code generation, multi-step plans) that previously truncated at ~3KB now stream through cleanly. [#144]
+
+### Fixed
+
+- **Graceful handling of `MaxTokensReachedException`** - The Strands converse Lambda now catches `MaxTokensReachedException` from the Strands SDK explicitly and emits a user-facing message ("your request required more processing than I can handle in a single response. Try breaking it into smaller steps or simplifying your request.") instead of falling through to the generic "I encountered an error" handler. Users get an actionable suggestion rather than a generic failure. [#144]
+
+---
+
 ## [0.25.1] - 2026-05-04
 
 ### Added

--- a/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
@@ -7,14 +7,19 @@ Stay up to date with the latest Pika Framework releases, new features, and impor
 
 ## Current Version
 
+### What's New in 0.25.2
+
+- **Strands converse Lambda `max_tokens` raised to 64000** - Both the main agent and collaborator `BedrockModel` configs now use Claude 4.5 Sonnet's actual max output (64K), up from a hardcoded 4096 leftover from older Claude defaults. Long-form responses (detailed explanations, code generation, multi-step plans) that previously truncated at ~3KB now stream through cleanly.
+- **Graceful `MaxTokensReachedException` handling** - When the model hits its max output limit, users now see "your request required more processing than I can handle in a single response. Try breaking it into smaller steps or simplifying your request." instead of a generic error message.
+
+**Latest Stable:** `0.25.2` (May 4, 2026)
+
 ### What's New in 0.25.1
 
 - **`useStrandsConverse` prop on PikaChatConstruct** - New optional boolean drives the converse Lambda SSM key (`converse_url` vs `converse_strands_url`). Reference `bin/pika-chat.ts` wires it from `pikaConfig.siteFeatures?.strandsConverse?.enabled`, so a single flag drives both the optional `ConverseStrandsConstruct` and the chat app's URL lookup. Closes a gap from 0.25.0 where the SSM key was hardcoded to `converse_url`, contradicting the conditional construct.
 - **`SessionInsightsSchedule` is now flag-gated, with a finer-grained `scheduleEnabled` knob** - The per-minute EventBridge rule that fires the insights runner Lambda is created only when `sessionInsightsFeature.enabled` is true AND `sessionInsightsFeature.scheduleEnabled` is not `false`. Set `scheduleEnabled: false` to deploy the runner Lambda and OpenSearch domain but skip the per-minute schedule (cost-control mode — keeps the infrastructure available for manual/backfill runs without idle Bedrock charges). Previously the rule fired every minute regardless of any flag.
 - **`userType` and `roles` propagated to DDB on login** - `apps/pika-chat/src/hooks.server.ts` now writes `userType` and `roles` from the auth provider through to `ChatUser` in DynamoDB, alongside `firstName`/`lastName`. The DDB write capability was added in 0.24.0; the call site was overlooked. Auth-provider changes to userType/roles now actually persist.
 - **Default `pnpm test` no longer hits AWS** - `apps/pika-chat/jest.config.js` excludes `test/integration/`; `services/pika/jest.config.cjs` excludes `chat-admin.test.ts` and `chat-session-os.test.ts`. New `test:integration` script in `apps/pika-chat/package.json` for opt-in runs.
-
-**Latest Stable:** `0.25.1` (May 4, 2026)
 
 ### What's New in 0.25.0
 
@@ -619,6 +624,7 @@ When breaking changes are introduced:
 
 | Version | Date        | Type     | Summary                                       |
 | ------- | ----------- | -------- | --------------------------------------------- |
+| 0.25.2  | May 4 2026  | Patch    | Strands converse Lambda: raise max_tokens to model capacity (64K), add explicit MaxTokensReachedException handler |
 | 0.25.1  | May 4 2026  | Patch    | Back-port gaps from 0.25.0: hooks userType/roles propagation, jest integration-test isolation, flag-gated insights schedule, flag-conditional Strands SSM lookup |
 | 0.25.0  | Apr 23 2026 | Feature  | Optional Python (Strands) converse Lambda, Claude 4.5/4.6 default models, streaming heartbeats, post-processor rewrite |
 | 0.24.0  | Mar 30 2026 | Feature  | Collaborator directive injection, server hook hardening, userType/roles persistence |

--- a/releases.json
+++ b/releases.json
@@ -1,7 +1,18 @@
 {
-  "latestVersion": "0.25.1",
-  "currentDevelopment": "0.25.1",
+  "latestVersion": "0.25.2",
+  "currentDevelopment": "0.25.2",
   "releases": [
+    {
+      "version": "0.25.2",
+      "date": "2026-05-04",
+      "status": "released",
+      "breaking": false,
+      "summary": "Strands converse Lambda: raise max_tokens to model capacity (64K) and add explicit MaxTokensReachedException handler",
+      "highlights": [
+        "max_tokens raised from 4096 → 64000 in both main agent and collaborator BedrockModel configs — Claude 4.5 Sonnet's actual max output. Long responses no longer truncate at ~3KB.",
+        "MaxTokensReachedException now caught explicitly with a user-facing 'try breaking into smaller steps' message, instead of falling through to the generic error handler"
+      ]
+    },
     {
       "version": "0.25.1",
       "date": "2026-05-04",

--- a/services/pika/src/lambda/converse-strands/handler.py
+++ b/services/pika/src/lambda/converse-strands/handler.py
@@ -15,6 +15,7 @@ from strands import Agent
 from strands.models.bedrock import BedrockModel, CacheConfig
 from strands.multiagent.swarm import Swarm
 from strands.tools.tools import PythonAgentTool
+from strands.types.exceptions import MaxTokensReachedException
 
 from pricing import extract_usage_from_result, extract_full_usage, calculate_usage
 from title import generate_session_title
@@ -1194,7 +1195,7 @@ def handler(event, context, chunk_queue: queue.Queue | None = None):
         # Configure Strands agent
         model = BedrockModel(
             model_id=model_id,
-            max_tokens=4096,
+            max_tokens=64000,
             cache_config=CacheConfig(strategy="auto"),
         )
 
@@ -1303,7 +1304,7 @@ def handler(event, context, chunk_queue: queue.Queue | None = None):
 
                     collab_model = BedrockModel(
                         model_id=collab_model_id,
-                        max_tokens=4096,
+                        max_tokens=64000,
                         cache_config=CacheConfig(strategy="auto"),
                     )
 
@@ -1521,6 +1522,10 @@ def handler(event, context, chunk_queue: queue.Queue | None = None):
                 # the callback; skip to avoid duplication.
                 if knowledge_bases and response_text:
                     stream.write(response_text)
+        except MaxTokensReachedException as e:
+            logger.error(f"Agent execution error: {e}")
+            response_text = "I'm sorry, your request required more processing than I can handle in a single response. Try breaking it into smaller steps or simplifying your request."
+            stream.write(response_text)
         except Exception as e:
             logger.error(f"Agent execution error: {e}")
             response_text = "I'm sorry, I encountered an error processing your request."


### PR DESCRIPTION
## Summary

Two general framework improvements ported from ai-bot. Final back-port from a comprehensive sweep of pika main vs ai-bot main following ES-3055 (v0.25.1) — single remaining gap.

## Changes

**File:** `services/pika/src/lambda/converse-strands/handler.py`

### `max_tokens=4096` → `max_tokens=64000` (×2 places)

Both the main agent and collaborator `BedrockModel` configurations had a hardcoded `max_tokens=4096`, leftover from older Claude defaults. Claude 4.5 Sonnet (the current default model) supports up to 64K output tokens, and Claude 4.6 supports 128K. Bumping to 64K unlocks the model's real output capacity for any consumer.

Long-form responses (detailed explanations, code generation, multi-step plans) that previously truncated at ~3KB now stream through cleanly.

Source: ai-bot commit `83313ea` (PR #112, ES-2352).

### Explicit `MaxTokensReachedException` handler

Added `from strands.types.exceptions import MaxTokensReachedException` and an explicit `except MaxTokensReachedException` block before the generic `except Exception` in the main agent execution try/except.

When the model hits `max_tokens`, users now see:

> I'm sorry, your request required more processing than I can handle in a single response. Try breaking it into smaller steps or simplifying your request.

Instead of the generic:

> I'm sorry, I encountered an error processing your request.

Defensive error-handling improvement, gives users actionable guidance.

Source: ai-bot commit `5005d4d`.

## Release artifacts

- `CHANGELOG.md` — v0.25.2 section with Changed / Fixed
- `releases.json` — v0.25.2 entry, `status: released`, `latestVersion` bumped
- `apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc` — synced
- `apps/pika-docs/src/content/docs/platform/releases/index.mdoc` — adds "What's New in 0.25.2", updates Latest Stable, adds 0.25.2 row to Version History

## Verification

- `pnpm --filter @pika/chat --filter @pika/service check-types` passes
- `pnpm --filter @pika/service test` — 112 tests pass
- `pnpm --filter pika-docs build` — 140 pages build clean

## Why this is general-purpose, not ai-bot-specific

- `max_tokens=64000` matches the deployed default model's actual output capacity (Claude 4.5 Sonnet). Any pika consumer benefits — there's no reason to artificially cap at 4096.
- `MaxTokensReachedException` handler is pure defensive error handling. Better UX for any consumer; no ai-bot-specific behavior.

## Task Reference

- Jira: https://chb.atlassian.net/browse/ES-3048
- Unblocks: https://chb.atlassian.net/browse/ES-3054 (ai-bot v0.25.0 sync, paused on this)

## Checklist

- [x] Code follows project style (4-space indent, single quotes)
- [x] Self-review completed
- [x] Existing tests pass; type-check clean; docs build
- [x] Release notes for v0.25.2 added across all 4 release files