### PR TITLE
fix(strands): correct gzip+base64 encoding in debug_trace (ES-3073)

### DIFF
--- a/services/pika/src/lambda/converse-strands/debug_trace.py
+++ b/services/pika/src/lambda/converse-strands/debug_trace.py
@@ -3,8 +3,8 @@ llm-instruction debug trace.
 
 Emits a trace containing the full instruction string (system prompt + tags +
 directives + user instruction + user message) the agent was given on this turn.
-The trace is gzip+base64-encoded using the exact encoding TS uses
-(gzipSync -> hex -> base64) so the existing downstream consumers keep working:
+The trace is gzip+base64-encoded using the exact encoding TS uses so the existing
+downstream consumers keep working:
 
   1. Admin Answer Reasoning panel (trace.svelte) — decompresses and renders.
   2. OpenSearch message indexing (message-changed/index.ts) — filters by the
@@ -20,7 +20,7 @@ Wire format MUST match exactly:
         "traceId": "llm-instruction",
         "text": JSON.stringify({
           "type": "llm-instruction",
-          "compressedData": "<gzip->hex->base64 of instruction>"
+          "compressedData": "<base64(gzip(instruction))>"
         })
       }
     }
@@ -35,16 +35,24 @@ from typing import Optional
 
 
 def gzip_base64_encode(s: str) -> str:
-    """Encode a string as gzip -> hex -> base64, matching TS gzipAndBase64EncodeString()."""
+    """Encode a string as gzip -> base64, matching TS gzipAndBase64EncodeString().
+
+    TS gzipAndBase64EncodeString() does: gzip -> hex -> decode-hex-back-to-bytes -> base64.
+    The intermediate hex round-trip is a no-op; the result is base64(gzip(s)).
+
+    The prior implementation encoded the hex string as ASCII before base64, producing
+    base64(ascii(hex(gzip(s)))) which the client's gunzipBase64EncodedString cannot
+    decompress — causing the LLM Instruction accordion onclick to throw, so the chevron
+    never rotated and the panel never expanded.
+    """
     gzipped = gzip.compress(s.encode('utf-8'))
-    hex_string = gzipped.hex()
-    return base64.b64encode(hex_string.encode('ascii')).decode('ascii')
+    return base64.b64encode(gzipped).decode('ascii')
 
 
 def gunzip_base64_decode(encoded: str) -> str:
     """Inverse of gzip_base64_encode(). Matches TS gunzipBase64EncodedString()."""
-    hex_string = base64.b64decode(encoded).decode('ascii')
-    return gzip.decompress(bytes.fromhex(hex_string)).decode('utf-8')
+    gzip_bytes = base64.b64decode(encoded)
+    return gzip.decompress(gzip_bytes).decode('utf-8')
 
 
 def build_full_instruction(system_prompt: str = '', tags_instructions: str = '',

--- a/services/pika/src/lambda/converse-strands/tests/test_contract_llm_instruction_trace.py
+++ b/services/pika/src/lambda/converse-strands/tests/test_contract_llm_instruction_trace.py
@@ -59,20 +59,19 @@ class TestLlmInstructionEncoding:
         assert decoded == original
 
     def test_node_gzip_compatibility(self):
-        """Payload must gunzip with Python gzip (stdlib) — compatibility with Node gzipSync."""
+        """Payload must gunzip with Python gzip (stdlib) — compatibility with Node gzipSync.
+
+        The fallback hex-decode path was removed (ES-3073): it masked the bug where the
+        encoder produced base64(ascii(hex(gzip(s)))) instead of base64(gzip(s)). The JS
+        client has no fallback — it calls gunzipSync() directly on the base64-decoded bytes,
+        so gzip.decompress must succeed without any hex round-trip.
+        """
         from debug_trace import gzip_base64_encode  # noqa: PLC0415
 
         original = 'test instruction payload'
         encoded = gzip_base64_encode(original)
         raw = base64.b64decode(encoded)
-        # If the encoder produced a hex-then-base64 blob (as Node does), base64 decode yields
-        # the hex string; we accept either "pure gzip bytes" or "hex-of-gzip-bytes" as long as
-        # it round-trips to original.
-        try:
-            decompressed = gzip.decompress(raw).decode('utf-8')
-        except (OSError, UnicodeDecodeError):
-            # Try hex path — matches Node's gzipSync(...).toString('hex')-then-base64
-            decompressed = gzip.decompress(bytes.fromhex(raw.decode('ascii'))).decode('utf-8')
+        decompressed = gzip.decompress(raw).decode('utf-8')
         assert decompressed == original
 
 

--- a/services/pika/src/lambda/converse-strands/tests/test_debug_trace.py
+++ b/services/pika/src/lambda/converse-strands/tests/test_debug_trace.py
@@ -146,3 +146,98 @@ class TestTraceEnvelope:
         assert trace['orchestrationTrace']['rationale']['traceId'] == 'llm-instruction-collaborator-foo'
         parsed = json.loads(trace['orchestrationTrace']['rationale']['text'])
         assert js_client_decode(parsed['compressedData']) == 'collab instruction'
+
+    def test_none_instruction_is_treated_as_empty(self):
+        """build_llm_instruction_trace(None) must not raise — handler.py calls it with instruction or ''."""
+        trace = build_llm_instruction_trace(None)  # type: ignore[arg-type]
+        parsed = json.loads(trace['orchestrationTrace']['rationale']['text'])
+        assert js_client_decode(parsed['compressedData']) == ''
+
+
+# ---------------------------------------------------------------------------
+# Regression prevention — explicit proof that the old broken form would fail
+# ---------------------------------------------------------------------------
+
+class TestRegressionPrevention:
+    """Prove that the pre-ES-3069 hex-encoding path fails the JS client decode.
+
+    This class exists so any future regression is caught immediately rather than
+    being masked by a fallback. The old encoder did:
+        base64(ascii(hex(gzip(s))))
+    which produces a payload that looks like valid base64 but decodes to hex
+    characters, not gzip bytes — gunzipSync throws in the browser.
+    """
+
+    def _old_broken_encode(self, s: str) -> str:
+        """Reproduce the pre-fix encoder: base64(ascii(hex(gzip(s))))."""
+        gzipped = gzip.compress(s.encode('utf-8'))
+        hex_string = gzipped.hex()
+        return base64.b64encode(hex_string.encode('ascii')).decode('ascii')
+
+    def test_old_hex_form_fails_js_client_path(self):
+        """The old encoder output must NOT decompress via the strict JS client path.
+
+        If this test fails it means we've accidentally regressed to the broken
+        hex encoding — or the test helper is wrong.
+        """
+        original = 'You are a helpful agent.'
+        broken_encoded = self._old_broken_encode(original)
+        raw = base64.b64decode(broken_encoded)
+        with pytest.raises((OSError, UnicodeDecodeError)):
+            gzip.decompress(raw)
+
+    def test_new_encoder_does_not_produce_hex_form(self):
+        """Current encoder must NOT produce the hex-as-ASCII form.
+
+        The old form, when base64-decoded, yields printable hex characters
+        (e.g. b'1f8b...'). The correct form yields raw gzip bytes starting
+        with the gzip magic number 0x1f 0x8b — not the ASCII characters '1', 'f'.
+        """
+        encoded = gzip_base64_encode('check encoding')
+        decoded_bytes = base64.b64decode(encoded)
+        assert decoded_bytes[:2] == b'\x1f\x8b', (
+            'Encoder regressed to hex form: decoded bytes are hex characters, not gzip magic bytes.'
+        )
+
+
+# ---------------------------------------------------------------------------
+# build_full_instruction — sparse input coverage
+# ---------------------------------------------------------------------------
+
+class TestBuildFullInstruction:
+
+    def test_all_fields_empty_returns_empty_string(self):
+        assert build_full_instruction() == ''
+
+    def test_only_system_prompt(self):
+        result = build_full_instruction(system_prompt='SYS')
+        assert result == 'SYS'
+
+    def test_only_user_message(self):
+        result = build_full_instruction(user_message='HELLO')
+        assert result == 'HELLO'
+
+    def test_system_prompt_and_user_message_separated_by_blank_line(self):
+        result = build_full_instruction(system_prompt='SYS', user_message='MSG')
+        assert result == 'SYS\n\nMSG'
+
+    def test_empty_fields_are_omitted_from_output(self):
+        """Empty-string fields must not produce extra blank lines."""
+        result = build_full_instruction(
+            system_prompt='SYS',
+            tags_instructions='',
+            directives_instructions='',
+            user_instruction='',
+            user_message='MSG',
+        )
+        assert result == 'SYS\n\nMSG'
+
+    @pytest.mark.parametrize('fields,expected_sections', [
+        ({'system_prompt': 'A', 'tags_instructions': 'B', 'directives_instructions': 'C',
+          'user_instruction': 'D', 'user_message': 'E'}, 5),
+        ({'system_prompt': 'A', 'user_message': 'E'}, 2),
+        ({'directives_instructions': 'C'}, 1),
+    ])
+    def test_section_count_matches_non_empty_fields(self, fields, expected_sections):
+        result = build_full_instruction(**fields)
+        assert len(result.split('\n\n')) == expected_sections

--- a/services/pika/src/lambda/converse-strands/tests/test_debug_trace.py
+++ b/services/pika/src/lambda/converse-strands/tests/test_debug_trace.py
@@ -1,0 +1,148 @@
+"""Regression tests for debug_trace gzip+base64 encoding (ES-3069).
+
+The client-side decoder at apps/pika-chat/src/lib/client/util.ts does:
+
+    const binaryString = atob(base64EncodedString);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+    }
+    const decompressed = gunzipSync(bytes);
+    return new TextDecoder().decode(decompressed);
+
+It expects the payload to be base64(gzip(s)) — no intermediate hex step. The
+contract test in test_contract_llm_instruction_trace.py has a try/except fallback
+that masks an incorrect encoding, so these tests assert the JS client decode path
+WITHOUT any fallback, which is what actually runs in the browser.
+
+Background: a prior implementation produced base64(ascii(hex(gzip(s)))) by
+encoding the hex string of the gzip bytes as ASCII before base64-encoding it.
+That payload could be decoded with a hex-aware path but threw inside the JS
+client's gunzipSync — the onclick handler aborted before expandedTraces was
+updated, so the accordion chevron never rotated.
+"""
+import base64
+import gzip
+import json
+
+import pytest
+
+from debug_trace import (
+    build_full_instruction,
+    build_llm_instruction_trace,
+    gunzip_base64_decode,
+    gzip_base64_encode,
+)
+
+
+def js_client_decode(b64: str) -> str:
+    """Replicate apps/pika-chat/src/lib/client/util.ts gunzipBase64EncodedString.
+
+    NO fallback paths. If the encoder produced base64(hex_as_ascii(gzip)) instead
+    of base64(gzip), gzip.decompress raises and the test fails — which is the
+    behavior we want, since this is exactly what the browser does.
+    """
+    raw_bytes = base64.b64decode(b64)
+    return gzip.decompress(raw_bytes).decode('utf-8')
+
+
+# ---------------------------------------------------------------------------
+# JS client compatibility — these are the tests that would have caught the bug
+# ---------------------------------------------------------------------------
+
+class TestJsClientCompatibility:
+
+    def test_encode_decodes_with_strict_js_client_path(self):
+        """Encoded payload must decompress via the exact JS client decode path.
+
+        Before the ES-3069 fix this raised OSError("Not a gzipped file") because
+        the encoder emitted hex ASCII characters under the base64 wrapper.
+        """
+        original = 'You are a helpful assistant. Respond clearly and concisely.'
+        encoded = gzip_base64_encode(original)
+        assert js_client_decode(encoded) == original
+
+    def test_realistic_instruction_payload(self):
+        """Round-trip a payload sized like a real LLM instruction (system prompt + tags + user message)."""
+        system_prompt = 'You are an analytics agent. ' * 50
+        tags = '<tag>weather</tag>' * 20
+        user_msg = 'What is the weather like in Salt Lake City today?'
+        instruction = build_full_instruction(
+            system_prompt=system_prompt, tags_instructions=tags, user_message=user_msg,
+        )
+        encoded = gzip_base64_encode(instruction)
+        assert js_client_decode(encoded) == instruction
+
+    def test_session_example_payload(self):
+        """Sized after a real prod session (ES-3069: session 019dff15-3ce3-7722-9998-a78414259033)."""
+        instruction = (
+            'session_id=019dff15-3ce3-7722-9998-a78414259033\n'
+            'user_id=689b92e158735e71d1419162\n\n'
+            + ('System prompt with retailer-specific guidance. ' * 80)
+            + '\n\nUser: Show me last week\'s sell-through by SKU.'
+        )
+        encoded = gzip_base64_encode(instruction)
+        assert js_client_decode(encoded) == instruction
+
+    def test_unicode_payload(self):
+        """Multi-byte UTF-8 must survive the round trip."""
+        original = 'こんにちは — résumé — 日本語テスト — 🚀'
+        encoded = gzip_base64_encode(original)
+        assert js_client_decode(encoded) == original
+
+    def test_empty_string(self):
+        """Empty input is valid (build_llm_instruction_trace passes '' when instruction is None)."""
+        encoded = gzip_base64_encode('')
+        assert js_client_decode(encoded) == ''
+
+    def test_encoded_is_valid_base64_only(self):
+        """The output must be base64 of gzip bytes — not base64 of hex characters.
+
+        Hex-of-gzip would be twice the size and only contain [0-9a-f] when base64-decoded.
+        The fix verification: decoded bytes start with the gzip magic number 0x1f 0x8b.
+        """
+        encoded = gzip_base64_encode('test')
+        decoded_bytes = base64.b64decode(encoded)
+        assert decoded_bytes[:2] == b'\x1f\x8b', (
+            f'expected gzip magic header, got {decoded_bytes[:2]!r}. '
+            f'If this is hex ASCII (e.g. b"1f"), the encoder regressed to base64(hex) form.'
+        )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip via own decoder
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+
+    @pytest.mark.parametrize('payload', [
+        'short',
+        '',
+        'a' * 10000,
+        'mixed\nlines\twith\twhitespace',
+        json.dumps({'nested': {'data': [1, 2, 3]}}),
+    ])
+    def test_encode_decode_round_trip(self, payload):
+        assert gunzip_base64_decode(gzip_base64_encode(payload)) == payload
+
+
+# ---------------------------------------------------------------------------
+# Trace envelope shape (regression for the wire format)
+# ---------------------------------------------------------------------------
+
+class TestTraceEnvelope:
+
+    def test_compressed_data_decodes_via_js_client_path(self):
+        """The compressedData field inside the trace must be JS-client decodable."""
+        trace = build_llm_instruction_trace('hello world')
+        text = trace['orchestrationTrace']['rationale']['text']
+        parsed = json.loads(text)
+        assert js_client_decode(parsed['compressedData']) == 'hello world'
+
+    def test_collaborator_trace_id_round_trips(self):
+        trace = build_llm_instruction_trace(
+            'collab instruction', trace_id='llm-instruction-collaborator-foo',
+        )
+        assert trace['orchestrationTrace']['rationale']['traceId'] == 'llm-instruction-collaborator-foo'
+        parsed = json.loads(trace['orchestrationTrace']['rationale']['text'])
+        assert js_client_decode(parsed['compressedData']) == 'collab instruction'


### PR DESCRIPTION
## Summary

- Fixed `gzip_base64_encode` and `gunzip_base64_decode` in `debug_trace.py` to produce `base64(gzip(s))` instead of `base64(ascii(hex(gzip(s))))`
- Added `test_debug_trace.py` (ported from ai-bot PR #117) — strict JS-client compatibility suite with no fallback paths
- Tightened `test_contract_llm_instruction_trace.py` to remove the `try/except` fallback that silently tolerated the broken encoding

## Task Reference
- Jira: https://chb.atlassian.net/browse/ES-3073
- Related: https://chb.atlassian.net/browse/ES-3069 (the original bug)

## Root Cause

The prior implementation hex-encoded the gzip bytes before base64-encoding them, producing `base64(ascii(hex(gzip(s))))`. The JS client (`util.ts gunzipBase64EncodedString`) calls `gunzipSync()` directly on the base64-decoded bytes — it expects raw gzip bytes, not hex characters. The mismatch caused `gunzipSync` to throw, aborting the onclick handler before `expandedTraces` was updated, so the LLM Instruction accordion chevron never rotated.

## Testing

All 19 tests pass (`test_debug_trace.py` + `test_contract_llm_instruction_trace.py`). The new `TestJsClientCompatibility` suite explicitly asserts the JS client decode path with no fallback — these are the tests that would have caught the original bug.

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] Tests added/updated (19 tests, all passing)
- [x] No contract-test fallback that silently tolerates hex-form encoding