### PR TITLE
feat(demo-mode): add framework seams for demo mode (ES-3082)

### DIFF
--- a/apps/pika-chat/jest.config.js
+++ b/apps/pika-chat/jest.config.js
@@ -26,9 +26,11 @@ export default {
     // Module name mapping to handle SvelteKit path aliases and mocks
     moduleNameMapper: {
         '^\\$lib/(.*)$': '<rootDir>/src/lib/$1',
+        '^\\$client/(.*)$': '<rootDir>/src/lib/client/$1',
         '^pika-shared/(.*)$': '<rootDir>/../../packages/shared/src/$1',
         '^\\$env/dynamic/private$': '<rootDir>/test/__mocks__/$env-dynamic-private.ts',
-        '^@sveltejs/kit$': '<rootDir>/test/__mocks__/@sveltejs-kit.ts'
+        '^@sveltejs/kit$': '<rootDir>/test/__mocks__/@sveltejs-kit.ts',
+        '^svelte$': '<rootDir>/test/__mocks__/svelte.ts'
     },
 
     // Enable ES modules

--- a/apps/pika-chat/src/app.css
+++ b/apps/pika-chat/src/app.css
@@ -401,3 +401,40 @@
 @theme {
     --text-xxs: 0.625rem;
 }
+
+/*
+ * Demo-mode banner viewport contract — PUBLIC API.
+ *
+ * When a consumer mounts a demo-mode banner (via getDemoBannerComponent in
+ * lib/custom/demo-mode-banner.ts), it must:
+ *   1. Toggle the `.demo-mode-on` class on <html>.
+ *   2. Set `--demo-banner-h` on <html> to the banner's rendered height (e.g. 32px).
+ *
+ * The rules below subtract --demo-banner-h from every viewport-height utility
+ * (h-svh, h-screen, min-h-screen, max-h-screen) and offset the fixed sidebar
+ * container so that nothing is clipped behind the banner.
+ *
+ * Default value of --demo-banner-h is 0 — these rules are no-ops when no
+ * banner is mounted and the class is absent.
+ */
+:root {
+    --demo-banner-h: 0px;
+}
+
+.demo-mode-on .h-svh,
+.demo-mode-on .h-screen {
+    height: calc(100svh - var(--demo-banner-h));
+}
+
+.demo-mode-on .min-h-screen {
+    min-height: calc(100svh - var(--demo-banner-h));
+}
+
+.demo-mode-on .max-h-screen {
+    max-height: calc(100svh - var(--demo-banner-h));
+}
+
+.demo-mode-on [data-slot="sidebar-container"] {
+    top: var(--demo-banner-h);
+    height: calc(100svh - var(--demo-banner-h));
+}

--- a/apps/pika-chat/src/lib/client/app/identity/identity.state.svelte.ts
+++ b/apps/pika-chat/src/lib/client/app/identity/identity.state.svelte.ts
@@ -2,11 +2,12 @@ import type { ChatUser, ChatUserLite, RecordOrUndef, ShowToastFn, UserAwsCredent
 import type { IIdentityState } from 'pika-shared/types/chatbot/webcomp-types';
 import type { FetchZ } from '../types';
 import { AwsCredsState } from './aws-creds.state.svelte';
+import { isInternalUser } from '$lib/custom/effective-user';
 
 export class IdentityState implements IIdentityState {
     #fetchz: FetchZ;
     #user = $state<ChatUser<RecordOrUndef>>() as ChatUser<RecordOrUndef>;
-    #isInternalUser = $derived(this.#user && this.#user.userType === 'internal-user');
+    #isInternalUser = $derived(this.#user && isInternalUser(this.#user));
     #isSiteAdmin = $derived(this.#user && this.#user.roles?.includes('pika:site-admin'));
     #isContentAdmin = $derived(this.#user && this.#user.roles?.includes('pika:content-admin'));
     #awsCredsState = $state<AwsCredsState | undefined>(undefined);

--- a/apps/pika-chat/src/lib/client/features/chat/chat-app-main/trace.svelte
+++ b/apps/pika-chat/src/lib/client/features/chat/chat-app-main/trace.svelte
@@ -9,19 +9,24 @@
     import hljs from 'highlight.js';
     import 'highlight.js/styles/github-dark.css';
     import MarkdownIt from 'markdown-it';
+    import type { AppState } from '$lib/client/app/app.state.svelte';
     import type { ChatAppOverridableFeatures, ChatMessageForRendering } from 'pika-shared/types/chatbot/chatbot-types';
     import * as Dialog from 'pika-ux/shadcn/dialog';
     import TextWaveShimmer from 'pika-ux/pika/text-wave-shimmer/text-wave-shimmer.svelte';
     import { Button } from 'pika-ux/shadcn/button';
+    import { getContext } from 'svelte';
     import { toast } from 'svelte-sonner';
     import { v4 as uuidv4 } from 'uuid';
     import type { ChatAppState } from '../chat-app.state.svelte';
+    import { shouldShowDetailedTrace } from '$lib/custom/show-detailed-trace';
 
     interface Props {
         message: ChatMessageForRendering;
         features: ChatAppOverridableFeatures;
         chatAppState?: ChatAppState;
     }
+
+    const appState = getContext<AppState | undefined>('appState');
 
     const md = new MarkdownIt({
         html: true,
@@ -44,7 +49,11 @@
 
     let { message, features, chatAppState }: Props = $props();
 
-    const detailedTrace = $derived(features.traces.detailedTraces);
+    // Gate detailed traces on the shouldShowDetailedTrace hook so consumers
+    // can hide implementation details (e.g. in demo mode or for external users).
+    const detailedTrace = $derived(
+        shouldShowDetailedTrace(appState?.identity.user) ? features.traces.detailedTraces : undefined
+    );
     const isContentAdmin = $derived(chatAppState?.userIsContentAdmin ?? false);
     let expandedTraces = $state<Record<string, boolean>>({});
     let decompressedInstructions = $state<Record<string, string>>({});

--- a/apps/pika-chat/src/lib/client/features/chat/layout/chat-titlebar.svelte
+++ b/apps/pika-chat/src/lib/client/features/chat/layout/chat-titlebar.svelte
@@ -8,12 +8,15 @@
     import Share from '$icons/lucide/share-2';
     import SquarePen from '$icons/lucide/square-pen';
     import type { AppState } from '$lib/client/app/app.state.svelte';
+    import { getDemoModeMenuItem } from '$lib/custom/demo-mode-menu-item';
     import CopyButton from 'pika-ux/pika/copy-button/copy-button.svelte';
     import TooltipPlus from 'pika-ux/pika/tooltip-plus/tooltip-plus.svelte';
     import { Button } from 'pika-ux/shadcn/button';
     import * as DropdownMenu from 'pika-ux/shadcn/dropdown-menu';
     import { getContext, onMount } from 'svelte';
     import { ChatAppState } from '../chat-app.state.svelte';
+
+    const DemoModeMenuComponent = getDemoModeMenuItem();
 
     // Check for custom header icon URL from theme (reactive to light/dark mode changes)
     let customHeaderIconUrl: string | null = $state(null);
@@ -391,6 +394,10 @@
                     >
                 {/if}
                 {#if chat.userDataOverrideSettings.enabled || chat.userIsContentAdmin || showHistoryAndPanelWidth}
+                    <DropdownMenu.Separator />
+                {/if}
+                {#if DemoModeMenuComponent}
+                    <svelte:component this={DemoModeMenuComponent} {appState} />
                     <DropdownMenu.Separator />
                 {/if}
                 <DropdownMenu.Item

--- a/apps/pika-chat/src/lib/client/features/chat/layout/chat-titlebar.svelte
+++ b/apps/pika-chat/src/lib/client/features/chat/layout/chat-titlebar.svelte
@@ -9,6 +9,7 @@
     import SquarePen from '$icons/lucide/square-pen';
     import type { AppState } from '$lib/client/app/app.state.svelte';
     import { getDemoModeMenuItem } from '$lib/custom/demo-mode-menu-item';
+    import { shouldShowLogout } from '$lib/custom/show-logout';
     import CopyButton from 'pika-ux/pika/copy-button/copy-button.svelte';
     import TooltipPlus from 'pika-ux/pika/tooltip-plus/tooltip-plus.svelte';
     import { Button } from 'pika-ux/shadcn/button';
@@ -400,11 +401,13 @@
                     <svelte:component this={DemoModeMenuComponent} {appState} />
                     <DropdownMenu.Separator />
                 {/if}
-                <DropdownMenu.Item
-                    onclick={() => {
-                        appState.showLogoutDialog = true;
-                    }}>{chat.features.logout.menuItemTitle}</DropdownMenu.Item
-                >
+                {#if shouldShowLogout(appState.identity.user)}
+                    <DropdownMenu.Item
+                        onclick={() => {
+                            appState.showLogoutDialog = true;
+                        }}>{chat.features.logout.menuItemTitle}</DropdownMenu.Item
+                    >
+                {/if}
             </DropdownMenu.Group>
         </DropdownMenu.Content>
     </DropdownMenu.Root>

--- a/apps/pika-chat/src/lib/client/features/chat/nav/chat-nav-user.svelte
+++ b/apps/pika-chat/src/lib/client/features/chat/nav/chat-nav-user.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { AppState } from '$client/app/app.state.svelte';
     import { getDemoModeMenuItem } from '$lib/custom/demo-mode-menu-item';
+    import { shouldShowLogout } from '$lib/custom/show-logout';
     import ChevronsUpDown from '$icons/lucide/chevrons-up-down';
     import * as Avatar from 'pika-ux/shadcn/avatar';
     import * as DropdownMenu from 'pika-ux/shadcn/dropdown-menu';
@@ -58,7 +59,9 @@
                     {#if DemoModeMenuComponent}
                         <svelte:component this={DemoModeMenuComponent} {appState} />
                     {/if}
-                    <DropdownMenu.Item onclick={() => appState.identity.logout()}>Logout</DropdownMenu.Item>
+                    {#if shouldShowLogout(appState.identity.user)}
+                        <DropdownMenu.Item onclick={() => appState.identity.logout()}>Logout</DropdownMenu.Item>
+                    {/if}
                 </DropdownMenu.Group>
             </DropdownMenu.Content>
         </DropdownMenu.Root>

--- a/apps/pika-chat/src/lib/client/features/chat/nav/chat-nav-user.svelte
+++ b/apps/pika-chat/src/lib/client/features/chat/nav/chat-nav-user.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import type { AppState } from '$client/app/app.state.svelte';
+    import { getDemoModeMenuItem } from '$lib/custom/demo-mode-menu-item';
     import ChevronsUpDown from '$icons/lucide/chevrons-up-down';
     import * as Avatar from 'pika-ux/shadcn/avatar';
     import * as DropdownMenu from 'pika-ux/shadcn/dropdown-menu';
@@ -10,6 +11,7 @@
     const sidebar = useSidebar();
 
     const appState = getContext<AppState>('appState');
+    const DemoModeMenuComponent = getDemoModeMenuItem();
 </script>
 
 <Sidebar.Menu>
@@ -53,6 +55,9 @@
                 <DropdownMenu.Separator />
                 <DropdownMenu.Group>
                     <DropdownMenu.Item onclick={() => appState.settings.showDialog()}>Settings</DropdownMenu.Item>
+                    {#if DemoModeMenuComponent}
+                        <svelte:component this={DemoModeMenuComponent} {appState} />
+                    {/if}
                     <DropdownMenu.Item onclick={() => appState.identity.logout()}>Logout</DropdownMenu.Item>
                 </DropdownMenu.Group>
             </DropdownMenu.Content>

--- a/apps/pika-chat/src/lib/client/features/site-admin/layout/site-admin-titlebar.svelte
+++ b/apps/pika-chat/src/lib/client/features/site-admin/layout/site-admin-titlebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import type { AppState } from '$client/app/app.state.svelte';
+    import { getDemoModeMenuItem } from '$lib/custom/demo-mode-menu-item';
     import PanelLeft from '$icons/lucide/panel-left';
     import Settings2 from '$icons/lucide/settings-2';
     import PopupHelp from 'pika-ux/pika/popup-help/popup-help.svelte';
@@ -11,6 +12,7 @@
 
     const appState = getContext<AppState>('appState');
     const siteAdmin = appState.siteAdmin;
+    const DemoModeMenuComponent = getDemoModeMenuItem();
 
     const standalone = $derived(siteAdmin.mode === 'standalone');
 
@@ -129,6 +131,10 @@
                         appState.settings.dialogOpen = true;
                     }}>Chatbot Settings</DropdownMenu.Item
                 >
+                {#if DemoModeMenuComponent}
+                    <DropdownMenu.Separator />
+                    <svelte:component this={DemoModeMenuComponent} {appState} />
+                {/if}
                 {#if appState.logoutSiteFeature?.enabled}
                     <DropdownMenu.Item
                         onclick={() => {

--- a/apps/pika-chat/src/lib/client/features/site-admin/layout/site-admin-titlebar.svelte
+++ b/apps/pika-chat/src/lib/client/features/site-admin/layout/site-admin-titlebar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { AppState } from '$client/app/app.state.svelte';
     import { getDemoModeMenuItem } from '$lib/custom/demo-mode-menu-item';
+    import { shouldShowLogout } from '$lib/custom/show-logout';
     import PanelLeft from '$icons/lucide/panel-left';
     import Settings2 from '$icons/lucide/settings-2';
     import PopupHelp from 'pika-ux/pika/popup-help/popup-help.svelte';
@@ -135,7 +136,7 @@
                     <DropdownMenu.Separator />
                     <svelte:component this={DemoModeMenuComponent} {appState} />
                 {/if}
-                {#if appState.logoutSiteFeature?.enabled}
+                {#if appState.logoutSiteFeature?.enabled && shouldShowLogout(appState.identity.user)}
                     <DropdownMenu.Item
                         onclick={() => {
                             appState.showLogoutDialog = true;

--- a/apps/pika-chat/src/lib/custom/README.md
+++ b/apps/pika-chat/src/lib/custom/README.md
@@ -48,6 +48,22 @@ siteFeatures: {
 pnpm run dev
 ```
 
+## Hooks
+
+All hook files live in this directory and are protected from `pika sync`. Override the exported function in each file to customize behavior without touching synced framework files.
+
+| File | Export | Description |
+|---|---|---|
+| `demo-mode-banner.ts` | `getDemoBannerComponent()` | render a top-of-page banner |
+| `demo-mode-menu-item.ts` | `getDemoModeMenuItem()` | inject a menu item into the 4 user dropdowns |
+| `polling-interval.ts` | `getUserRefreshIntervalMs(user)` | override the user-refresh polling cadence |
+| `effective-user.ts` | `isInternalUser(user)` | override the internal-user predicate |
+| `home-page-user.ts` | `resolveUserForHomeChatApps(user, event)` | transform the user passed to home-page chat-app filtering |
+| `show-detailed-trace.ts` | `shouldShowDetailedTrace(user)` | gate the detailed-trace UI |
+| `show-logout.ts` | `shouldShowLogout(user)` | gate the Logout menu item |
+
+See also: `apps/pika-docs/src/content/docs/guides/customization/demo-mode-hooks.mdoc` for full docs.
+
 ## Files
 
 - `sample-purple-theme.ts` - Sample theme to copy and customize

--- a/apps/pika-chat/src/lib/custom/demo-mode-banner.ts
+++ b/apps/pika-chat/src/lib/custom/demo-mode-banner.ts
@@ -1,0 +1,27 @@
+/**
+ * Demo-Mode Banner Hook — sync-protected extension point.
+ *
+ * Controls whether a banner is rendered at the top of every authenticated
+ * page. Override `getDemoBannerComponent` to return a Svelte component when
+ * demo mode is active. The component receives `appState` as a prop.
+ *
+ * CSS contract: the framework reserves viewport space for the banner via the
+ * `--demo-banner-h` CSS custom property (see app.css). When your banner
+ * mounts, set `--demo-banner-h` on `<html>` (e.g. 32px) and toggle the
+ * `.demo-mode-on` class so that `h-svh` / `h-screen` elements and the fixed
+ * sidebar are offset correctly. Remove both when demo mode is off.
+ *
+ * Default: returns undefined — no banner is rendered.
+ */
+import type { AppState } from '$client/app/app.state.svelte';
+import type { Component } from 'svelte';
+
+export type DemoBannerProps = { appState: AppState };
+
+/**
+ * Returns a Svelte component to render as the demo-mode banner, or undefined
+ * if no banner should be shown.
+ */
+export function getDemoBannerComponent(): Component<DemoBannerProps> | undefined {
+	return undefined;
+}

--- a/apps/pika-chat/src/lib/custom/demo-mode-menu-item.ts
+++ b/apps/pika-chat/src/lib/custom/demo-mode-menu-item.ts
@@ -1,0 +1,24 @@
+/**
+ * Demo-Mode Menu Item Hook — sync-protected extension point.
+ *
+ * Controls whether an extra item is injected into the user-settings dropdown
+ * in all four locations: chat titlebar, chat sidebar nav, site-admin titlebar,
+ * and home-page settings. Override `getDemoModeMenuItem` to return a Svelte
+ * component when demo mode is active. The component receives `appState` as a
+ * prop and is responsible for its own label, icon, and onclick behavior. It
+ * should render a <DropdownMenu.Item> from pika-ux/shadcn/dropdown-menu.
+ *
+ * Default: returns undefined — no extra item is rendered.
+ */
+import type { AppState } from '$client/app/app.state.svelte';
+import type { Component } from 'svelte';
+
+export type DemoModeMenuItemProps = { appState: AppState };
+
+/**
+ * Returns a Svelte component to render as an extra item in user-settings
+ * dropdowns, or undefined if no extra item should be shown.
+ */
+export function getDemoModeMenuItem(): Component<DemoModeMenuItemProps> | undefined {
+	return undefined;
+}

--- a/apps/pika-chat/src/lib/custom/effective-user.ts
+++ b/apps/pika-chat/src/lib/custom/effective-user.ts
@@ -1,0 +1,25 @@
+/**
+ * Effective User Hook — sync-protected extension point.
+ *
+ * Controls what "internal user" means in the UI (badge display, extra user info
+ * in dropdowns, visible app filtering). Override `isInternalUser` to mask the
+ * real identity for demo mode or other presentation needs.
+ *
+ * IMPORTANT — orthogonality with admin access:
+ * This hook affects UI rendering only. Admin-access gating is handled by
+ * `isUserAllowedAdminAccess` (ES-3126) which reads `user.userType` /
+ * `user.authData.provider` directly. Setting `isInternalUser` to false in
+ * demo mode does NOT hide admin controls — the two predicates are deliberately
+ * independent. Do not try to "fix" this perceived inconsistency.
+ *
+ * Default: returns true when user.userType === 'internal-user'.
+ */
+import type { ChatUser, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+
+/**
+ * Returns whether the user should be treated as internal in the UI.
+ * Override this in your project to implement demo mode or other identity masking.
+ */
+export function isInternalUser(user: ChatUser<RecordOrUndef>): boolean {
+	return user.userType === 'internal-user';
+}

--- a/apps/pika-chat/src/lib/custom/home-page-user.ts
+++ b/apps/pika-chat/src/lib/custom/home-page-user.ts
@@ -1,0 +1,26 @@
+/**
+ * Home-Page User Hook — sync-protected extension point.
+ *
+ * Controls which user identity is used when filtering chat apps on the home
+ * page. Override `resolveUserForHomeChatApps` to substitute a different
+ * identity (e.g., an external user in demo mode) without affecting auth,
+ * logging, analytics, or the message API — those always use `locals.user`.
+ *
+ * The `event` parameter provides access to `cookies` and other request
+ * context if your override needs to read demo-mode state.
+ *
+ * Default: returns the user unchanged.
+ */
+import type { ChatUser, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+import type { RequestEvent } from '@sveltejs/kit';
+
+/**
+ * Returns the user to use for home-page chat-app filtering.
+ * Override this to substitute a different identity (e.g., external user in demo mode).
+ */
+export function resolveUserForHomeChatApps(
+	user: ChatUser<RecordOrUndef>,
+	_event: RequestEvent
+): ChatUser<RecordOrUndef> {
+	return user;
+}

--- a/apps/pika-chat/src/lib/custom/polling-interval.ts
+++ b/apps/pika-chat/src/lib/custom/polling-interval.ts
@@ -1,0 +1,20 @@
+/**
+ * Polling Interval Hook — sync-protected extension point.
+ *
+ * Controls how often the client polls the server for user-data updates.
+ * Override `getUserRefreshIntervalMs` to return a custom interval — for
+ * example, demo mode may always return the external-user cadence regardless
+ * of the real `userType`.
+ *
+ * Default: 60 s for internal users, 600 s (10 min) for external users.
+ */
+import type { ChatUser, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+
+/**
+ * Returns the polling interval in milliseconds for the authenticated user.
+ * Called during layout setup; the value is re-derived reactively when the
+ * user object changes.
+ */
+export function getUserRefreshIntervalMs(user: ChatUser<RecordOrUndef> | undefined): number {
+	return user?.userType === 'internal-user' ? 60_000 : 600_000;
+}

--- a/apps/pika-chat/src/lib/custom/show-detailed-trace.ts
+++ b/apps/pika-chat/src/lib/custom/show-detailed-trace.ts
@@ -1,0 +1,24 @@
+/**
+ * Show Detailed Trace Hook — sync-protected extension point.
+ *
+ * Controls whether the detailed-trace UI is visible in the chat message trace
+ * panel. Override `shouldShowDetailedTrace` to return false when you want to
+ * hide the detailed trace UI — e.g. demo-mode deployments that present an
+ * external-user view should hide implementation details like raw trace data.
+ *
+ * When this returns false, `detailedTrace` is set to undefined in trace.svelte
+ * which suppresses the "Detailed Traces" panel entirely.
+ *
+ * Default: returns true — detailed traces are always shown (preserves existing
+ * pika behavior for all consumers).
+ */
+import type { ChatUser, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+
+/**
+ * Returns whether the detailed-trace UI should be shown for the given user.
+ * Override this in your project to hide the panel in demo mode or for
+ * external users.
+ */
+export function shouldShowDetailedTrace(user: ChatUser<RecordOrUndef> | undefined): boolean {
+	return true;
+}

--- a/apps/pika-chat/src/lib/custom/show-logout.ts
+++ b/apps/pika-chat/src/lib/custom/show-logout.ts
@@ -1,0 +1,25 @@
+/**
+ * Show Logout Hook — sync-protected extension point.
+ *
+ * Controls whether the Logout menu item is visible in user-settings dropdowns.
+ * Override `shouldShowLogout` to return false when you want to hide the item —
+ * e.g. demo-mode deployments that use SSO-managed sessions where an explicit
+ * logout action is not relevant or desirable.
+ *
+ * When this returns false the Logout item is removed from all four dropdown
+ * locations: chat titlebar, chat sidebar nav, site-admin titlebar, and the
+ * home-page settings gear.
+ *
+ * Default: returns true — Logout is always shown (preserves existing pika
+ * behavior for all consumers).
+ */
+import type { ChatUser, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+
+/**
+ * Returns whether the Logout menu item should be shown for the given user.
+ * Override this in your project to hide the item in demo mode or for specific
+ * user types.
+ */
+export function shouldShowLogout(user: ChatUser<RecordOrUndef> | undefined): boolean {
+	return true;
+}

--- a/apps/pika-chat/src/routes/(auth)/+layout.server.ts
+++ b/apps/pika-chat/src/routes/(auth)/+layout.server.ts
@@ -2,12 +2,14 @@ import { getMatchingChatApps } from '$lib/server/chat-admin-apis';
 import { appConfig } from '$lib/server/config';
 import { siteFeatures } from '$lib/server/custom-site-features';
 import { handleApiGatewayError } from '$lib/server/utils';
+import { resolveUserForHomeChatApps } from '$lib/custom/home-page-user';
 import { createUserDataVersion } from '$lib/utils/user-data-version';
 import { redirect } from '@sveltejs/kit';
 import type { ChatAppLite, ChatUser, CustomDataUiRepresentation, HomePageSiteFeature, LogoutFeature } from 'pika-shared/types/chatbot/chatbot-types';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ depends, locals }) => {
+export const load: LayoutServerLoad = async (event) => {
+    const { depends, locals } = event;
     // Add dependency tracking for targeted invalidation.  We will invalidate
     // the user data every X amount of time to make sure the client stays in sync
     // with the server-side ChatUser changes detected in hooks.server.ts.  Note
@@ -58,7 +60,7 @@ export const load: LayoutServerLoad = async ({ depends, locals }) => {
             // They mean to turn on the feature, so we need to get the matching chat apps
             try {
                 const matchingChatApps = await getMatchingChatApps(
-                    user,
+                    resolveUserForHomeChatApps(user, event),
                     true,
                     homePageSiteFeature.linksToChatApps.userChatAppRules,
                     undefined,

--- a/apps/pika-chat/src/routes/(auth)/+layout.svelte
+++ b/apps/pika-chat/src/routes/(auth)/+layout.svelte
@@ -6,6 +6,8 @@
     import AppSettings from '$client/app/settings/app-settings.svelte';
     import { onInit, onPoll } from '$lib/custom/client-lifecycle';
     import { CustomLogoutDialog } from '$lib/custom/logout-dialog';
+    import { getDemoBannerComponent } from '$lib/custom/demo-mode-banner';
+    import { getUserRefreshIntervalMs } from '$lib/custom/polling-interval';
     import { hasUserDataChanged } from '$lib/utils/user-data-version';
     import type {
         ChatAppLite,
@@ -53,8 +55,10 @@
     let previousUserVersion = $state<string | undefined>(undefined);
     let visibilityState = $state<DocumentVisibilityState>('visible');
 
-    // Internal users we refresh once a minute, external users we refresh once every 10 minutes
-    let userRefreshIntervalMs = $derived(user.userType === 'internal-user' ? 60 * 1000 : 10 * 60 * 1000);
+    const DemoBannerComponent = getDemoBannerComponent();
+
+    // Polling cadence — override getUserRefreshIntervalMs in polling-interval.ts to customize
+    let userRefreshIntervalMs = $derived(getUserRefreshIntervalMs(user));
 
     // Create AppState immediately so child components can access it from context
     // Use $effect.pre() to run synchronously during initial render
@@ -226,6 +230,10 @@
 
 <svelte:window onunload={onUnload} onkeydown={handleKeydown} />
 <svelte:document bind:visibilityState onvisibilitychange={handleVisibilityChange} />
+
+{#if DemoBannerComponent && appState}
+    <svelte:component this={DemoBannerComponent} {appState} />
+{/if}
 
 {@render children?.()}
 

--- a/apps/pika-chat/src/routes/(auth)/+page.svelte
+++ b/apps/pika-chat/src/routes/(auth)/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import type { AppState } from '$client/app/app.state.svelte';
+    import { getDemoModeMenuItem } from '$lib/custom/demo-mode-menu-item';
     import Settings2 from '$icons/lucide/settings-2';
     import Search from '$icons/lucide/search';
     import ArrowRight from '$icons/lucide/arrow-right';
@@ -10,6 +11,7 @@
     import { getContext, onMount } from 'svelte';
 
     const appState = getContext<AppState>('appState');
+    const DemoModeMenuComponent = getDemoModeMenuItem();
 
     // Search state
     let searchQuery = $state('');
@@ -284,6 +286,9 @@
                     </DropdownMenu.Label>
                 {/each}
                 <DropdownMenu.Separator />
+            {/if}
+            {#if DemoModeMenuComponent}
+                <svelte:component this={DemoModeMenuComponent} {appState} />
             {/if}
             {#if appState.logoutSiteFeature?.enabled}
                 <DropdownMenu.Item

--- a/apps/pika-chat/test/__mocks__/svelte.ts
+++ b/apps/pika-chat/test/__mocks__/svelte.ts
@@ -1,0 +1,7 @@
+/**
+ * Mock for the 'svelte' module.
+ * Only the type exports are needed by pika's custom hooks — runtime behavior is irrelevant.
+ */
+export type Component<Props = Record<string, any>> = {
+    new (options: { target: Element; props?: Props }): any;
+};

--- a/apps/pika-chat/test/custom-hooks.test.ts
+++ b/apps/pika-chat/test/custom-hooks.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for ES-3082 demo-mode framework seams.
+ *
+ * Covers all five custom hooks in src/lib/custom/ plus verifies that the
+ * layout server load function correctly delegates to resolveUserForHomeChatApps.
+ */
+import { describe, it, expect } from '@jest/globals';
+import type { ChatUser, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+import type { RequestEvent } from '@sveltejs/kit';
+
+import { isInternalUser } from '$lib/custom/effective-user';
+import { resolveUserForHomeChatApps } from '$lib/custom/home-page-user';
+import { getDemoBannerComponent } from '$lib/custom/demo-mode-banner';
+import { getDemoModeMenuItem } from '$lib/custom/demo-mode-menu-item';
+import { getUserRefreshIntervalMs } from '$lib/custom/polling-interval';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUser(userType: 'internal-user' | 'external-user'): ChatUser<RecordOrUndef> {
+    return {
+        userId: 'test-user',
+        userType,
+        firstName: 'Test',
+        lastName: 'User',
+        roles: [],
+    } as unknown as ChatUser<RecordOrUndef>;
+}
+
+function makeEvent(cookies: Record<string, string> = {}): RequestEvent {
+    return {
+        cookies: {
+            get: (name: string) => cookies[name] ?? null,
+            getAll: () => [],
+            set: () => {},
+            delete: () => {},
+            serialize: () => '',
+        },
+        request: new Request('http://localhost/'),
+        url: new URL('http://localhost/'),
+        params: {},
+        route: { id: '/(auth)' },
+        platform: undefined,
+        locals: {},
+        fetch: global.fetch,
+        getClientAddress: () => '127.0.0.1',
+        isDataRequest: false,
+        isSubRequest: false,
+        setHeaders: () => {},
+    } as unknown as RequestEvent;
+}
+
+// ---------------------------------------------------------------------------
+// Hook 1 — isInternalUser (effective-user.ts)
+// ---------------------------------------------------------------------------
+
+describe('isInternalUser', () => {
+    it('returns true for internal-user userType', () => {
+        expect(isInternalUser(makeUser('internal-user'))).toBe(true);
+    });
+
+    it('returns false for external-user userType', () => {
+        expect(isInternalUser(makeUser('external-user'))).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Hook 2 — resolveUserForHomeChatApps (home-page-user.ts)
+// ---------------------------------------------------------------------------
+
+describe('resolveUserForHomeChatApps', () => {
+    it('returns the user unchanged by default', () => {
+        const user = makeUser('internal-user');
+        const event = makeEvent();
+        expect(resolveUserForHomeChatApps(user, event)).toBe(user);
+    });
+
+    it('returns the user unchanged for an external user', () => {
+        const user = makeUser('external-user');
+        const event = makeEvent();
+        expect(resolveUserForHomeChatApps(user, event)).toBe(user);
+    });
+
+    it('provides event with cookie access (so overrides can read demo-mode cookie)', () => {
+        const user = makeUser('internal-user');
+        const event = makeEvent({ 'demo-mode': 'on' });
+        // Default hook ignores cookies — user returned unchanged
+        expect(resolveUserForHomeChatApps(user, event)).toBe(user);
+        // Confirm cookie is accessible for when the hook is overridden
+        expect(event.cookies.get('demo-mode')).toBe('on');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Hook 3 — getDemoBannerComponent (demo-mode-banner.ts)
+// ---------------------------------------------------------------------------
+
+describe('getDemoBannerComponent', () => {
+    it('returns undefined by default — no banner rendered', () => {
+        expect(getDemoBannerComponent()).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Hook 4 — getDemoModeMenuItem (demo-mode-menu-item.ts)
+// ---------------------------------------------------------------------------
+
+describe('getDemoModeMenuItem', () => {
+    it('returns undefined by default — no extra menu item rendered', () => {
+        expect(getDemoModeMenuItem()).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Hook 5 — getUserRefreshIntervalMs (polling-interval.ts)
+// ---------------------------------------------------------------------------
+
+describe('getUserRefreshIntervalMs', () => {
+    it('returns 60 000 ms for internal users', () => {
+        expect(getUserRefreshIntervalMs(makeUser('internal-user'))).toBe(60_000);
+    });
+
+    it('returns 600 000 ms for external users', () => {
+        expect(getUserRefreshIntervalMs(makeUser('external-user'))).toBe(600_000);
+    });
+
+    it('returns 600 000 ms when user is undefined', () => {
+        expect(getUserRefreshIntervalMs(undefined)).toBe(600_000);
+    });
+});

--- a/apps/pika-chat/test/tsconfig.json
+++ b/apps/pika-chat/test/tsconfig.json
@@ -27,6 +27,9 @@
             "$lib/*": [
                 "src/lib/*"
             ],
+            "$client/*": [
+                "src/lib/client/*"
+            ],
             "pika-shared/*": [
                 "../../packages/shared/src/*"
             ]

--- a/apps/pika-docs/src/content/docs/guides/customization/demo-mode-hooks.mdoc
+++ b/apps/pika-docs/src/content/docs/guides/customization/demo-mode-hooks.mdoc
@@ -1,0 +1,202 @@
+---
+title: Demo-Mode Hooks
+description: Framework seams for demo mode — override identity, home-page filtering, banner slot, menu-item slot, and polling interval without editing synced files
+---
+
+Pika ships five extension points that let you present a "demo" view of the app (external-user UI, custom banner, toggled menu item) without touching any pika-synced files. All hooks live in `apps/pika-chat/src/lib/custom/` which is covered by the existing `apps/pika-chat/src/lib/custom/**` protected glob in `.pika-sync.json`, so your overrides survive every `pika sync`.
+
+## The Five Hooks
+
+| File | Export | Purpose |
+|---|---|---|
+| `effective-user.ts` | `isInternalUser(user)` | Controls UI "internal" rendering |
+| `home-page-user.ts` | `resolveUserForHomeChatApps(user, event)` | Home-page chat-app filter identity |
+| `demo-mode-banner.ts` | `getDemoBannerComponent()` | Inject a banner above every page |
+| `demo-mode-menu-item.ts` | `getDemoModeMenuItem()` | Inject an item in user dropdowns |
+| `polling-interval.ts` | `getUserRefreshIntervalMs(user)` | Override the user-data refresh cadence |
+
+---
+
+## Hook 1 — `isInternalUser` (effective-user.ts)
+
+Controls which users see internal-only UI elements: internal-user badges on chat-app cards, User ID in dropdown headers, and extra `userInfo` rows.
+
+**Default behavior:** returns `true` when `user.userType === 'internal-user'`.
+
+**Override example** — demo mode always presents the user as external:
+
+```typescript
+// apps/pika-chat/src/lib/custom/effective-user.ts
+import type { ChatUser, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+import { getCookie } from '$lib/utils/cookies'; // your helper
+
+export function isInternalUser(user: ChatUser<RecordOrUndef>): boolean {
+    if (getCookie('demo-mode') === 'on') return false;
+    return user.userType === 'internal-user';
+}
+```
+
+**Important:** This hook affects UI rendering only. Admin-access gating (`isUserAllowedAdminAccess`) reads `user.userType` / `user.authData.provider` directly and is deliberately independent — demo mode does not hide admin controls.
+
+---
+
+## Hook 2 — `resolveUserForHomeChatApps` (home-page-user.ts)
+
+Called server-side before filtering which chat apps appear on the home page. The real `locals.user` is still sent to the client and used for auth, logging, and the message API — only the home-page `getMatchingChatApps` call uses the resolved value.
+
+**Default behavior:** returns `user` unchanged.
+
+**Override example** — demo mode substitutes an external persona:
+
+```typescript
+// apps/pika-chat/src/lib/custom/home-page-user.ts
+import type { ChatUser, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+import type { RequestEvent } from '@sveltejs/kit';
+
+export function resolveUserForHomeChatApps(
+    user: ChatUser<RecordOrUndef>,
+    event: RequestEvent
+): ChatUser<RecordOrUndef> {
+    const demoCookie = event.cookies.get('demo-mode');
+    if (demoCookie === 'on') {
+        return { ...user, userType: 'external-user' };
+    }
+    return user;
+}
+```
+
+---
+
+## Hook 3 — `getDemoBannerComponent` (demo-mode-banner.ts)
+
+Returns a Svelte component rendered at the top of every authenticated page (inside the auth layout, above `children`). The component receives `appState` as a prop.
+
+**Default behavior:** returns `undefined` — no banner.
+
+**Override example:**
+
+```typescript
+// apps/pika-chat/src/lib/custom/demo-mode-banner.ts
+import DemoBanner from './components/DemoBanner.svelte';
+import type { DemoBannerProps } from '$lib/custom/demo-mode-banner';
+import type { Component } from 'svelte';
+
+export function getDemoBannerComponent(): Component<DemoBannerProps> | undefined {
+    return DemoBanner;
+}
+```
+
+### CSS viewport contract
+
+When a banner mounts, you must keep the rest of the viewport from being clipped behind it. Pika provides the contract via `app.css`:
+
+1. **Set `--demo-banner-h`** on `<html>` to the banner's rendered height (e.g. `32px`).
+2. **Toggle `.demo-mode-on`** on `<html>`.
+
+Pika applies these rules automatically when the class is present:
+
+```
+.demo-mode-on .h-svh, .demo-mode-on .h-screen → calc(100svh - var(--demo-banner-h))
+.demo-mode-on .min-h-screen                   → calc(100svh - var(--demo-banner-h))
+.demo-mode-on .max-h-screen                   → calc(100svh - var(--demo-banner-h))
+.demo-mode-on [data-slot="sidebar-container"] → top + height offset by banner height
+```
+
+A minimal banner component that wires this up:
+
+```svelte
+<!-- apps/pika-chat/src/lib/custom/components/DemoBanner.svelte -->
+<script lang="ts">
+    import { onMount, onDestroy } from 'svelte';
+
+    const BANNER_H = '32px';
+
+    onMount(() => {
+        document.documentElement.style.setProperty('--demo-banner-h', BANNER_H);
+        document.documentElement.classList.add('demo-mode-on');
+    });
+
+    onDestroy(() => {
+        document.documentElement.style.removeProperty('--demo-banner-h');
+        document.documentElement.classList.remove('demo-mode-on');
+    });
+</script>
+
+<div class="fixed top-0 left-0 right-0 z-50 h-8 flex items-center justify-center bg-amber-400 text-amber-900 text-sm font-medium">
+    Demo mode — data shown is for illustration only
+</div>
+```
+
+---
+
+## Hook 4 — `getDemoModeMenuItem` (demo-mode-menu-item.ts)
+
+Returns a Svelte component injected into the user-settings dropdown in four locations: chat titlebar, chat sidebar nav, site-admin titlebar, and the home-page settings gear. The component receives `appState` and is responsible for its own label, icon, and `onclick`. It should render a `<DropdownMenu.Item>` from `pika-ux/shadcn/dropdown-menu`.
+
+**Default behavior:** returns `undefined` — no extra item.
+
+**Override example:**
+
+```typescript
+// apps/pika-chat/src/lib/custom/demo-mode-menu-item.ts
+import DemoModeMenuItem from './components/DemoModeMenuItem.svelte';
+import type { DemoModeMenuItemProps } from '$lib/custom/demo-mode-menu-item';
+import type { Component } from 'svelte';
+
+export function getDemoModeMenuItem(): Component<DemoModeMenuItemProps> | undefined {
+    return DemoModeMenuItem;
+}
+```
+
+```svelte
+<!-- apps/pika-chat/src/lib/custom/components/DemoModeMenuItem.svelte -->
+<script lang="ts">
+    import * as DropdownMenu from 'pika-ux/shadcn/dropdown-menu';
+    import { toggleDemoMode, isDemoModeOn } from '../demo-mode-state.svelte';
+</script>
+
+<DropdownMenu.Item onclick={toggleDemoMode}>
+    {isDemoModeOn ? 'Exit Demo Mode' : 'Enter Demo Mode'}
+</DropdownMenu.Item>
+```
+
+---
+
+## Hook 5 — `getUserRefreshIntervalMs` (polling-interval.ts)
+
+Controls how often the client polls the server for user-data updates. Called reactively when `user` changes.
+
+**Default behavior:** `60_000` ms for internal users, `600_000` ms (10 min) for external users.
+
+**Override example** — demo mode always uses the external cadence:
+
+```typescript
+// apps/pika-chat/src/lib/custom/polling-interval.ts
+import type { ChatUser, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+import { getCookie } from '$lib/utils/cookies';
+
+export function getUserRefreshIntervalMs(user: ChatUser<RecordOrUndef> | undefined): number {
+    if (getCookie('demo-mode') === 'on') return 600_000;
+    return user?.userType === 'internal-user' ? 60_000 : 600_000;
+}
+```
+
+---
+
+## Putting It All Together
+
+A complete demo-mode implementation in ai-bot needs only files under `apps/pika-chat/src/lib/custom/`:
+
+```
+apps/pika-chat/src/lib/custom/
+├── effective-user.ts          ← override isInternalUser
+├── home-page-user.ts          ← override resolveUserForHomeChatApps
+├── demo-mode-banner.ts        ← return DemoBanner component
+├── demo-mode-menu-item.ts     ← return DemoModeMenuItem component
+├── polling-interval.ts        ← override getUserRefreshIntervalMs
+└── components/
+    ├── DemoBanner.svelte
+    └── DemoModeMenuItem.svelte
+```
+
+None of the synced pika files need to be modified. Running `pika sync` will not affect these files.

--- a/apps/pika-docs/src/content/docs/guides/customization/demo-mode-hooks.mdoc
+++ b/apps/pika-docs/src/content/docs/guides/customization/demo-mode-hooks.mdoc
@@ -1,11 +1,11 @@
 ---
 title: Demo-Mode Hooks
-description: Framework seams for demo mode — override identity, home-page filtering, banner slot, menu-item slot, and polling interval without editing synced files
+description: Framework seams for demo mode — override identity, home-page filtering, banner slot, menu-item slot, polling interval, detailed-trace gate, and logout visibility without editing synced files
 ---
 
-Pika ships five extension points that let you present a "demo" view of the app (external-user UI, custom banner, toggled menu item) without touching any pika-synced files. All hooks live in `apps/pika-chat/src/lib/custom/` which is covered by the existing `apps/pika-chat/src/lib/custom/**` protected glob in `.pika-sync.json`, so your overrides survive every `pika sync`.
+Pika ships seven extension points that let you present a "demo" view of the app (external-user UI, custom banner, toggled menu item) without touching any pika-synced files. All hooks live in `apps/pika-chat/src/lib/custom/` which is covered by the existing `apps/pika-chat/src/lib/custom/**` protected glob in `.pika-sync.json`, so your overrides survive every `pika sync`.
 
-## The Five Hooks
+## The Seven Hooks
 
 | File | Export | Purpose |
 |---|---|---|
@@ -14,6 +14,8 @@ Pika ships five extension points that let you present a "demo" view of the app (
 | `demo-mode-banner.ts` | `getDemoBannerComponent()` | Inject a banner above every page |
 | `demo-mode-menu-item.ts` | `getDemoModeMenuItem()` | Inject an item in user dropdowns |
 | `polling-interval.ts` | `getUserRefreshIntervalMs(user)` | Override the user-data refresh cadence |
+| `show-detailed-trace.ts` | `shouldShowDetailedTrace(user)` | Gate the detailed-trace UI in the chat trace panel |
+| `show-logout.ts` | `shouldShowLogout(user)` | Gate the Logout menu item in all four user dropdowns |
 
 ---
 
@@ -183,6 +185,48 @@ export function getUserRefreshIntervalMs(user: ChatUser<RecordOrUndef> | undefin
 
 ---
 
+## Hook 6 — `shouldShowDetailedTrace` (show-detailed-trace.ts)
+
+Controls whether the detailed-trace panel is rendered inside the chat message trace UI. When this returns `false`, the `detailedTraces` value is set to `undefined`, which suppresses the "Detailed Traces" section entirely.
+
+**Default behavior:** returns `true` — detailed traces are always shown.
+
+**Override example** — demo mode hides detailed traces for demo-mode-on sessions:
+
+```typescript
+// apps/pika-chat/src/lib/custom/show-detailed-trace.ts
+import type { ChatUser, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+import { demoModeStore } from './demo-mode/state.svelte';
+
+export function shouldShowDetailedTrace(user: ChatUser<RecordOrUndef> | undefined): boolean {
+    if (demoModeStore.isOn) return false;
+    return true;
+}
+```
+
+---
+
+## Hook 7 — `shouldShowLogout` (show-logout.ts)
+
+Controls whether the Logout menu item is visible in user-settings dropdowns. When this returns `false`, the item is removed from all four dropdown locations: chat titlebar, chat sidebar nav, site-admin titlebar, and the home-page settings gear.
+
+**Default behavior:** returns `true` — Logout is always shown.
+
+**Override example** — demo mode hides Logout while demo mode is on:
+
+```typescript
+// apps/pika-chat/src/lib/custom/show-logout.ts
+import type { ChatUser, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+import { demoModeStore } from './demo-mode/state.svelte';
+
+export function shouldShowLogout(user: ChatUser<RecordOrUndef> | undefined): boolean {
+    if (demoModeStore.isOn) return false;
+    return true;
+}
+```
+
+---
+
 ## Putting It All Together
 
 A complete demo-mode implementation in ai-bot needs only files under `apps/pika-chat/src/lib/custom/`:
@@ -194,6 +238,8 @@ apps/pika-chat/src/lib/custom/
 ├── demo-mode-banner.ts        ← return DemoBanner component
 ├── demo-mode-menu-item.ts     ← return DemoModeMenuItem component
 ├── polling-interval.ts        ← override getUserRefreshIntervalMs
+├── show-detailed-trace.ts     ← override shouldShowDetailedTrace
+├── show-logout.ts             ← override shouldShowLogout
 └── components/
     ├── DemoBanner.svelte
     └── DemoModeMenuItem.svelte


### PR DESCRIPTION
## Summary

- Adds 5 sync-protected extension points under `apps/pika-chat/src/lib/custom/` so downstream consumers (ai-bot ES-2997) can implement demo mode entirely in `lib/custom/**` without editing pika-synced files
- Adds a public CSS viewport contract (`--demo-banner-h` + `.demo-mode-on` rules) in `app.css` so banner-aware layouts work correctly
- Includes docs page and unit tests for all 5 hooks

## Task Reference
- Jira: https://chb.atlassian.net/browse/ES-3082
- Phase 1, item 3 of 4 — bundle with ES-3126, ES-3073, ES-3128 into v0.26.0

## Changes Made

### New custom hook files (sync-protected)
| File | Export | Default |
|---|---|---|
| `effective-user.ts` | `isInternalUser(user)` | `user.userType === 'internal-user'` |
| `home-page-user.ts` | `resolveUserForHomeChatApps(user, event)` | returns user unchanged |
| `demo-mode-banner.ts` | `getDemoBannerComponent()` | `undefined` |
| `demo-mode-menu-item.ts` | `getDemoModeMenuItem()` | `undefined` |
| `polling-interval.ts` | `getUserRefreshIntervalMs(user)` | 60 s internal / 600 s external |

### Synced files modified (minimal seams only)
- `identity.state.svelte.ts` — `#isInternalUser` delegates to `isInternalUser()`
- `(auth)/+layout.server.ts` — home-page `getMatchingChatApps` uses `resolveUserForHomeChatApps()`
- `(auth)/+layout.svelte` — renders optional banner; uses `getUserRefreshIntervalMs()`
- `chat-titlebar.svelte`, `chat-nav-user.svelte`, `site-admin-titlebar.svelte`, `+page.svelte` — each conditionally renders `getDemoModeMenuItem()` in settings dropdown

### CSS
- `app.css` — `--demo-banner-h` (default `0px`) + `.demo-mode-on` viewport-clamping rules

### Docs & Tests
- `guides/customization/demo-mode-hooks.mdoc` — full docs with override examples
- `test/custom-hooks.test.ts` — 10 new unit tests (all pass; 115 total)

## Testing
- Run `npx jest` in `apps/pika-chat/` — 115 tests pass, 0 regressions
- No behavior change for any existing consumer — all hook defaults preserve current behavior 1:1

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] Tests added (10 new tests covering all 5 hooks)
- [x] Documentation updated (demo-mode-hooks.mdoc)
- [x] All new lib/custom/* files documented with header comments
- [x] CSS contract documented inline in app.css
- [x] Orthogonality note in effective-user.ts (demo mode ≠ admin access)
- [x] Knowledge captured