### PR TITLE
feat(infra): port ES-3068 docker build-cache optimization (ES-3128)

### DIFF
--- a/apps/pika-chat/infra/lib/stacks/pika-chat-construct.ts
+++ b/apps/pika-chat/infra/lib/stacks/pika-chat-construct.ts
@@ -185,12 +185,21 @@ export class PikaChatConstruct extends Construct {
         // Build the full domain name
 
         // Create Docker image asset
+        // cacheFrom is only set when DOCKER_CACHE_FROM_GHA=true (CI deploys via deploy.yml).
+        // The GHA cache is populated by the build job; this lets CDK's asset publisher skip the
+        // full Docker build and use cached layers instead (near-instant on cache hit).
+        // docker buildx --cache-from type=gha silently no-ops locally when ACTIONS_CACHE_URL is not set.
+        const dockerCacheFrom = process.env.DOCKER_CACHE_FROM_GHA === 'true'
+            ? [{ type: 'gha' as const }]
+            : undefined;
+
         this.dockerImage = new ecr_assets.DockerImageAsset(this, `${props.projNameTitleCase}Image`, {
             directory: props.dockerBuildPath,
             buildArgs: {
                 BUILDPLATFORM: 'linux/amd64'
             },
-            platform: ecr_assets.Platform.LINUX_AMD64
+            platform: ecr_assets.Platform.LINUX_AMD64,
+            ...(dockerCacheFrom && { cacheFrom: dockerCacheFrom })
         });
         this.applyComponentTags(this.dockerImage, 'DockerImageAsset');
 


### PR DESCRIPTION
## Summary

- Adds GHA build-cache support to `DockerImageAsset` in `pika-chat-construct.ts`
- When `DOCKER_CACHE_FROM_GHA=true` (set by CI `deploy.yml`), CDK passes `--cache-from type=gha` to docker buildx so CDK's asset publisher can skip the full Docker build and reuse cached layers from the preceding build job
- Silently no-ops locally when `ACTIONS_CACHE_URL` is not set

## Task Reference

- Jira: https://chb.atlassian.net/browse/ES-3128
- Task: ES-3128
- Part of Phase 1 pika release alongside ES-3126, ES-3073, ES-3082

## Changes Made

- `apps/pika-chat/infra/lib/stacks/pika-chat-construct.ts` — added `dockerCacheFrom` conditional const + spread into `DockerImageAsset` options; inline comment explains the GHA cache conditional pattern

## Testing

- No behavior change for local deploys (env var gate)
- In CI, `DOCKER_CACHE_FROM_GHA=true` must be set in the deploy workflow for cache hits to occur
- Diff between ai-bot and pika versions is now clean for this file

## Decision Log

**DECISION**: Targeted `feat/ES-3126-azuread-extension-points` as base branch rather than `main`  
**Confidence**: High  
**Rationale**: ES-3128 is Phase 1 item 4 — rides along in the same pika release as ES-3126. Basing on ES-3126's branch lets both PRs merge together; ES-3128 will rebase onto main after ES-3126 merges.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No tests required (infrastructure/CDK change, no logic under test)
- [x] Inline comment added per documentation requirement
- [x] Diff between ai-bot and pika cleared for ES-3068-related lines