### PR TITLE
feat(services): services library improvements — debug instrumentation, account normalization, admin session enrichment

### DIFF
--- a/apps/pika-docs/src/content/docs/reference/configuration/environment-variables.mdoc
+++ b/apps/pika-docs/src/content/docs/reference/configuration/environment-variables.mdoc
@@ -97,6 +97,18 @@ Feature flags are typically configured in `pika-config.ts` rather than environme
 | `DISABLE_USER_MEMORY` | `boolean` | Disable user memory feature |
 | `DISABLE_INSIGHTS` | `boolean` | Disable session insights |
 
+### Debug Logging
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `CHAT_DEBUG_LOGS` | `'true'` \| `'false'` | `'false'` | Enable verbose session debug logging in the chat and admin APIs. When `'true'`, Lambda functions log raw DDB item keys, account-ID fields found, session-attribute contents, and each step of `ensureChatSession`/`addChatMessage`. **Disable in production** — outputs are intended for debugging account-context issues only and can be noisy. Has zero cost when `'false'` (all checks are `=== 'true'` comparisons). |
+
+### Account ID Field Names
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `PIKA_ACCOUNT_ID_FIELD_NAMES` | `string` (comma-separated) | `'accountId,account_id'` | Comma-separated list of field names to search when normalizing an account ID out of `sessionAttributes`. Tried in order. Set automatically by CDK from `pikaConfig.accountIdFieldNames`. Most consumers do not need to override this. |
+
 ## Local Development
 
 ### Local .env File Example

--- a/apps/pika-docs/src/content/docs/reference/configuration/platform-settings.mdoc
+++ b/apps/pika-docs/src/content/docs/reference/configuration/platform-settings.mdoc
@@ -601,6 +601,36 @@ userMemory: {
 }
 ```
 
+## Account ID Field Names
+
+Controls which field names are searched when normalizing an account ID out of a user's `sessionAttributes`. The normalized value is projected onto the top-level session row so admin tables and search results always have a consistent `accountId` column.
+
+```typescript
+accountIdFieldNames?: string[];
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `accountIdFieldNames` | `string[]` | `['accountId', 'account_id']` | Field names tried in order against `sessionAttributes` (and the nested `account` sub-object). |
+
+**When to use:** Override this when your user records store the account identifier under a different or additional field name (e.g., legacy B2B systems using `retailerId` or `supplierId`). The default covers the two canonical pika field names; consumers should only extend this list, not replace it.
+
+**Example:**
+
+```typescript
+// pika-config.ts
+export const pikaConfig: PikaConfig = {
+    // ... project names, siteFeatures ...
+    accountIdFieldNames: ['accountId', 'account_id', 'retailerId', 'supplierId']
+};
+```
+
+The value is passed to Lambda functions as the `PIKA_ACCOUNT_ID_FIELD_NAMES` environment variable (comma-joined). Consumers that do not set this option get the default `['accountId', 'account_id']` behavior with no change to existing sessions.
+
+{% aside type="note" title="Behavior on upgrade" %}
+Adding field names is non-breaking. Existing sessions that already have `accountId` or `account_id` are unaffected. New or legacy sessions that only have an account ID under a custom field name will now surface it in admin queries.
+{% /aside %}
+
 ## Complete Example
 
 ```typescript

--- a/packages/shared/src/types/chatbot/chatbot-types.ts
+++ b/packages/shared/src/types/chatbot/chatbot-types.ts
@@ -3977,6 +3977,21 @@ export interface PikaConfig {
          */
         componentTagNames?: string[];
     };
+
+    /**
+     * Field names to search when normalizing an account ID out of session attributes.
+     * Tried in order against sessionAttributes (top-level keys) and the nested `account` object.
+     *
+     * Default: `['accountId', 'account_id']`
+     *
+     * Override when your user records use additional or legacy field names, e.g.:
+     * ```typescript
+     * accountIdFieldNames: ['accountId', 'account_id', 'retailerId', 'supplierId']
+     * ```
+     *
+     * @since 0.26.0
+     */
+    accountIdFieldNames?: string[];
 }
 
 /**

--- a/services/pika/lib/constructs/pika-construct.ts
+++ b/services/pika/lib/constructs/pika-construct.ts
@@ -35,6 +35,8 @@ export interface PikaConstructProps {
     userMemoryFeature: UserMemoryFeature;
     stackTags?: Record<string, string>;
     componentTagNames?: string[];
+    /** Field names used to normalize account ID from session attributes. Comma-joined into PIKA_ACCOUNT_ID_FIELD_NAMES env var. */
+    accountIdFieldNames?: string[];
 }
 
 export interface PikaConstructOutputs {
@@ -1819,7 +1821,8 @@ export class PikaConstruct extends Construct {
                 ...(openSearchDomain ? { PIKA_DOMAIN_ENDPOINT: openSearchDomain.domainEndpoint } : {}),
                 ...(memoryId ? { MEMORY_ID: memoryId } : {}),
                 ...(sharedSessionVisitHistoryTable ? { SHARED_SESSION_VISIT_HISTORY_TABLE: sharedSessionVisitHistoryTable.tableName } : {}),
-                ...(pinnedSessionTable ? { PINNED_SESSION_TABLE: pinnedSessionTable.tableName } : {})
+                ...(pinnedSessionTable ? { PINNED_SESSION_TABLE: pinnedSessionTable.tableName } : {}),
+                ...(this.props.accountIdFieldNames?.length ? { PIKA_ACCOUNT_ID_FIELD_NAMES: this.props.accountIdFieldNames.join(',') } : {})
             },
             bundling: {
                 minify: true,
@@ -1954,7 +1957,8 @@ export class PikaConstruct extends Construct {
                 ...(chatSessionFeedbackTable ? { CHAT_SESSION_FEEDBACK_TABLE: chatSessionFeedbackTable.tableName } : {}),
                 ...(openSearchDomain ? { PIKA_DOMAIN_ENDPOINT: openSearchDomain.domainEndpoint } : {}),
                 ...(memoryId ? { MEMORY_ID: memoryId } : {}),
-                ...(memoryStrategies ? { MEMORY_STRATEGIES: JSON.stringify(memoryStrategies) } : {})
+                ...(memoryStrategies ? { MEMORY_STRATEGIES: JSON.stringify(memoryStrategies) } : {}),
+                ...(this.props.accountIdFieldNames?.length ? { PIKA_ACCOUNT_ID_FIELD_NAMES: this.props.accountIdFieldNames.join(',') } : {})
             },
             bundling: {
                 minify: true,
@@ -2060,7 +2064,8 @@ export class PikaConstruct extends Construct {
                 ...(openSearchDomain ? { PIKA_DOMAIN_ENDPOINT: openSearchDomain.domainEndpoint } : {}),
                 POST_PROCESSOR_FUNCTION_ARN: agentPostProcessorFn.functionArn,
                 ...(memoryId ? { MEMORY_ID: memoryId } : {}),
-                ...inferenceProfileEnvVars
+                ...inferenceProfileEnvVars,
+                ...(this.props.accountIdFieldNames?.length ? { PIKA_ACCOUNT_ID_FIELD_NAMES: this.props.accountIdFieldNames.join(',') } : {})
             },
             bundling: {
                 minify: true,

--- a/services/pika/lib/stacks/pika-stack.ts
+++ b/services/pika/lib/stacks/pika-stack.ts
@@ -48,7 +48,8 @@ export class PikaStack extends cdk.Stack {
                 sessionInsightsFeature: props.sessionInsightsFeature,
                 userMemoryFeature: props.userMemoryFeature,
                 stackTags: processedTags,
-                componentTagNames: props.pikaConfig.stackTags?.componentTagNames
+                componentTagNames: props.pikaConfig.stackTags?.componentTagNames,
+                accountIdFieldNames: props.pikaConfig.accountIdFieldNames
             })
         );
 

--- a/services/pika/src/lib/chat-admin-apis.ts
+++ b/services/pika/src/lib/chat-admin-apis.ts
@@ -124,6 +124,7 @@ import {
 } from './chat-admin-utils';
 import { MODEL_ID_TO_MODEL } from './model-types-utils';
 import { queryForSessionAnalytics, queryForSessions } from './opensearch/opensearch';
+import { getAccountIdFieldNames } from './utils';
 
 function handleCustomFieldUpdate(
     newCustom: Record<string, unknown> | null | undefined,
@@ -1565,30 +1566,45 @@ export async function searchForSessions(search: SessionSearchRequest<RecordOrUnd
     return response;
 }
 
-/** Returns the top-level accountId/account_id value from a session row, or undefined. */
+/**
+ * Returns the top-level account ID value from a session row, or undefined.
+ * Iterates over `getAccountIdFieldNames()` so `PIKA_ACCOUNT_ID_FIELD_NAMES` controls resolution.
+ */
 function extractTopLevelAccountId(session: ChatSession<RecordOrUndef>): string | undefined {
     const r = session as unknown as Record<string, unknown>;
-    const v = r.accountId ?? r.account_id;
-    if (typeof v === 'string' && v.length > 0) return v;
-    if (typeof v === 'number') return String(v);
+    for (const field of getAccountIdFieldNames()) {
+        const v = r[field];
+        if (typeof v === 'string' && v.length > 0) return v;
+        if (typeof v === 'number') return String(v);
+    }
     return undefined;
 }
 
-/** Returns the accountId/account_id value nested inside sessionAttributes, or undefined. */
+/**
+ * Returns the account ID value nested inside sessionAttributes, or undefined.
+ * Iterates over `getAccountIdFieldNames()` so `PIKA_ACCOUNT_ID_FIELD_NAMES` controls resolution.
+ */
 function extractSessionAttributesAccountId(session: ChatSession<RecordOrUndef>): string | undefined {
     const attrs = (session as unknown as Record<string, unknown>).sessionAttributes as Record<string, unknown> | undefined;
     if (!attrs) return undefined;
-    const v = attrs.accountId ?? attrs.account_id;
-    if (typeof v === 'string' && v.length > 0) return v;
-    if (typeof v === 'number') return String(v);
+    for (const field of getAccountIdFieldNames()) {
+        const v = attrs[field];
+        if (typeof v === 'string' && v.length > 0) return v;
+        if (typeof v === 'number') return String(v);
+    }
     return undefined;
 }
 
-/** Extracts a string account ID from an arbitrary data record (e.g., user customData). */
+/**
+ * Extracts a string account ID from an arbitrary data record (e.g., user customData).
+ * Iterates over `getAccountIdFieldNames()` so `PIKA_ACCOUNT_ID_FIELD_NAMES` controls resolution.
+ */
 function extractAccountIdFromRecord(data: Record<string, unknown>): string | undefined {
-    const v = data.accountId ?? data.account_id;
-    if (typeof v === 'string' && v.length > 0) return v;
-    if (typeof v === 'number') return String(v);
+    for (const field of getAccountIdFieldNames()) {
+        const v = data[field];
+        if (typeof v === 'string' && v.length > 0) return v;
+        if (typeof v === 'number') return String(v);
+    }
     return undefined;
 }
 

--- a/services/pika/src/lib/chat-admin-apis.ts
+++ b/services/pika/src/lib/chat-admin-apis.ts
@@ -33,6 +33,7 @@ import type {
     ChatAppOverride,
     ChatAppOverrideDdb,
     ChatAppOverrideForCreateOrUpdate,
+    ChatSession,
     ChatSessionFeedback,
     ChatSessionFeedbackForCreate,
     ChatSessionFeedbackForUpdate,
@@ -103,7 +104,7 @@ import {
     updateFeedback,
     updateTool
 } from './chat-admin-ddb';
-import { batchGetUsersByUserIds } from './chat-admin-ddb';
+import { batchGetUsersByUserIds, batchGetUserCustomDataByUserIds } from './chat-admin-ddb';
 import {
     agentsAreSame,
     arraysAreSame,
@@ -1524,14 +1525,71 @@ export async function updateChatSessionFeedback(feedback: ChatSessionFeedbackFor
 }
 
 export async function searchForSessions(search: SessionSearchRequest<RecordOrUndef>): Promise<SessionSearchResponse<RecordOrUndef>> {
-    // Log what we're about to pass to the OS query layer
+    const response = await queryForSessions<RecordOrUndef>(search);
+
+    // Enrich sessions missing account context by looking up user customData from DDB.
+    // This handles sessions created before account tracking was implemented.
     try {
-        console.log('searchForSessions: calling queryForSessions with', JSON.stringify(search, null, 2));
+        const sessionsNeedingEnrichment = response.sessions.filter(
+            (s) => !extractTopLevelAccountId(s) && !extractSessionAttributesAccountId(s)
+        );
+        if (sessionsNeedingEnrichment.length > 0) {
+            const userIds = [
+                ...new Set(
+                    sessionsNeedingEnrichment
+                        .map((s) => s.userId)
+                        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+                )
+            ];
+            if (userIds.length > 0) {
+                const customDataMap = await batchGetUserCustomDataByUserIds(userIds);
+                for (const session of sessionsNeedingEnrichment) {
+                    const customData = session.userId ? customDataMap.get(session.userId) : undefined;
+                    if (!customData) continue;
+                    const accountId = extractAccountIdFromRecord(customData as Record<string, unknown>);
+                    if (accountId) {
+                        const sessionRecord = session as unknown as Record<string, unknown>;
+                        sessionRecord.accountId = accountId;
+                        if (!sessionRecord.sessionAttributes || typeof sessionRecord.sessionAttributes !== 'object') {
+                            sessionRecord.sessionAttributes = {};
+                        }
+                        (sessionRecord.sessionAttributes as Record<string, unknown>).accountId = accountId;
+                    }
+                }
+            }
+        }
     } catch (e) {
-        console.warn('searchForSessions: failed to log request payload', e);
+        console.warn('searchForSessions account enrichment failed (non-fatal):', e instanceof Error ? e.message : e);
     }
 
-    return await queryForSessions<RecordOrUndef>(search);
+    return response;
+}
+
+/** Returns the top-level accountId/account_id value from a session row, or undefined. */
+function extractTopLevelAccountId(session: ChatSession<RecordOrUndef>): string | undefined {
+    const r = session as unknown as Record<string, unknown>;
+    const v = r.accountId ?? r.account_id;
+    if (typeof v === 'string' && v.length > 0) return v;
+    if (typeof v === 'number') return String(v);
+    return undefined;
+}
+
+/** Returns the accountId/account_id value nested inside sessionAttributes, or undefined. */
+function extractSessionAttributesAccountId(session: ChatSession<RecordOrUndef>): string | undefined {
+    const attrs = (session as unknown as Record<string, unknown>).sessionAttributes as Record<string, unknown> | undefined;
+    if (!attrs) return undefined;
+    const v = attrs.accountId ?? attrs.account_id;
+    if (typeof v === 'string' && v.length > 0) return v;
+    if (typeof v === 'number') return String(v);
+    return undefined;
+}
+
+/** Extracts a string account ID from an arbitrary data record (e.g., user customData). */
+function extractAccountIdFromRecord(data: Record<string, unknown>): string | undefined {
+    const v = data.accountId ?? data.account_id;
+    if (typeof v === 'string' && v.length > 0) return v;
+    if (typeof v === 'number') return String(v);
+    return undefined;
 }
 
 /**

--- a/services/pika/src/lib/chat-admin-ddb.ts
+++ b/services/pika/src/lib/chat-admin-ddb.ts
@@ -2578,3 +2578,70 @@ export async function batchGetUsersByUserIds(userIds: string[]): Promise<ChatUse
 
     return allUsers;
 }
+
+/**
+ * Batch-fetch the `customData` field for a list of user IDs.
+ * Uses BatchGetItem for efficiency, processing in batches of 100 with p-retry.
+ *
+ * @param userIds - User IDs to fetch custom data for
+ * @returns Map of userId → customData (entries missing from DDB are omitted)
+ */
+export async function batchGetUserCustomDataByUserIds(userIds: string[]): Promise<Map<string, RecordOrUndef>> {
+    if (userIds.length === 0) {
+        return new Map();
+    }
+
+    const BATCH_SIZE = 100;
+    const result = new Map<string, RecordOrUndef>();
+
+    for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
+        const chunk = userIds.slice(i, i + BATCH_SIZE);
+
+        const users = await pRetry(
+            async () => {
+                const keys = chunk.map((userId) => ({ user_id: userId }));
+
+                const response = await ddbDocClient.batchGet({
+                    RequestItems: {
+                        [getChatUserTable()]: {
+                            Keys: keys,
+                            ProjectionExpression: 'user_id, custom_data'
+                        }
+                    }
+                });
+
+                if (response.UnprocessedKeys && Object.keys(response.UnprocessedKeys).length > 0) {
+                    console.warn('Some keys were unprocessed in batch get user customData operation, will retry');
+                    throw new HttpStatusError('Unprocessed keys detected', 500);
+                }
+
+                return (response.Responses?.[getChatUserTable()] || []).map((item) => {
+                    const camelItem = convertChatUserToCamelFromSnakeCase(item as SnakeCase<ChatUser>);
+                    return { userId: camelItem.userId, customData: camelItem.customData };
+                });
+            },
+            {
+                retries: 3,
+                factor: 2,
+                minTimeout: 100,
+                maxTimeout: 2000,
+                onFailedAttempt: (error) => {
+                    if (isRetryableError(error)) {
+                        console.warn(`Batch get user customData attempt ${error.attemptNumber} failed, retrying:`, error.message);
+                    } else {
+                        console.warn('Non-retryable error in batch get user customData:', error.message);
+                        throw new AbortError(error.message);
+                    }
+                }
+            }
+        );
+
+        for (const u of users) {
+            if (u.userId) {
+                result.set(u.userId, u.customData ?? undefined);
+            }
+        }
+    }
+
+    return result;
+}

--- a/services/pika/src/lib/chat-apis.ts
+++ b/services/pika/src/lib/chat-apis.ts
@@ -73,7 +73,7 @@ import {
     updateSessionTitleInDdb
 } from './chat-ddb';
 import { getMatchingChatApps } from './get-matching-chat-apps';
-import { createSessionToken, getNextMessageId, validateUserCanAccessSession } from './utils';
+import { createSessionToken, getAccountBackfillAttributes, hasSessionAccountContext, getNextMessageId, validateUserCanAccessSession } from './utils';
 
 function toStringId(value: unknown): string | undefined {
     if (typeof value === 'string' && value.length > 0) {
@@ -83,54 +83,6 @@ function toStringId(value: unknown): string | undefined {
         return String(value);
     }
     return undefined;
-}
-
-function hasSessionAccountContext(session: ChatSession<RecordOrUndef>): boolean {
-    const sessionRecord = session as unknown as Record<string, unknown>;
-    const topLevelAccountId = sessionRecord.accountId ?? sessionRecord.account_id;
-    if (toStringId(topLevelAccountId)) {
-        return true;
-    }
-
-    const sessionAttributes = (sessionRecord.sessionAttributes as Record<string, unknown> | undefined) ?? undefined;
-    const sessionAttributesAccountId = sessionAttributes?.accountId ?? sessionAttributes?.account_id;
-    if (toStringId(sessionAttributesAccountId)) {
-        return true;
-    }
-
-    const accountObject = sessionAttributes?.account;
-    if (accountObject && typeof accountObject === 'object' && !Array.isArray(accountObject)) {
-        const accountRecord = accountObject as Record<string, unknown>;
-        return !!toStringId(accountRecord.id ?? accountRecord.accountId ?? accountRecord.account_id);
-    }
-
-    return false;
-}
-
-function getAccountBackfillAttributes(customUserData: Record<string, unknown> | undefined): Record<string, unknown> {
-    if (!customUserData) {
-        return {};
-    }
-
-    const allowedKeys = [
-        'accountId',
-        'account_id',
-        'accountType',
-        'account_type',
-        'accountName',
-        'account_name',
-        'account'
-    ];
-
-    const attributes: Record<string, unknown> = {};
-    for (const key of allowedKeys) {
-        const value = customUserData[key];
-        if (value !== undefined && value !== null) {
-            attributes[key] = value;
-        }
-    }
-
-    return attributes;
 }
 
 function isChatDebugLogsEnabled(): boolean {

--- a/services/pika/src/lib/chat-apis.ts
+++ b/services/pika/src/lib/chat-apis.ts
@@ -61,6 +61,7 @@ import {
     getUserPrefsByUserId,
     getUserSessionsByUserId,
     markSessionAsShared,
+    mergeSessionAttributes,
     pinSession,
     recordSharedSessionVisit,
     revokeSharedSession,
@@ -73,6 +74,68 @@ import {
 } from './chat-ddb';
 import { getMatchingChatApps } from './get-matching-chat-apps';
 import { createSessionToken, getNextMessageId, validateUserCanAccessSession } from './utils';
+
+function toStringId(value: unknown): string | undefined {
+    if (typeof value === 'string' && value.length > 0) {
+        return value;
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    return undefined;
+}
+
+function hasSessionAccountContext(session: ChatSession<RecordOrUndef>): boolean {
+    const sessionRecord = session as unknown as Record<string, unknown>;
+    const topLevelAccountId = sessionRecord.accountId ?? sessionRecord.account_id;
+    if (toStringId(topLevelAccountId)) {
+        return true;
+    }
+
+    const sessionAttributes = (sessionRecord.sessionAttributes as Record<string, unknown> | undefined) ?? undefined;
+    const sessionAttributesAccountId = sessionAttributes?.accountId ?? sessionAttributes?.account_id;
+    if (toStringId(sessionAttributesAccountId)) {
+        return true;
+    }
+
+    const accountObject = sessionAttributes?.account;
+    if (accountObject && typeof accountObject === 'object' && !Array.isArray(accountObject)) {
+        const accountRecord = accountObject as Record<string, unknown>;
+        return !!toStringId(accountRecord.id ?? accountRecord.accountId ?? accountRecord.account_id);
+    }
+
+    return false;
+}
+
+function getAccountBackfillAttributes(customUserData: Record<string, unknown> | undefined): Record<string, unknown> {
+    if (!customUserData) {
+        return {};
+    }
+
+    const allowedKeys = [
+        'accountId',
+        'account_id',
+        'accountType',
+        'account_type',
+        'accountName',
+        'account_name',
+        'account'
+    ];
+
+    const attributes: Record<string, unknown> = {};
+    for (const key of allowedKeys) {
+        const value = customUserData[key];
+        if (value !== undefined && value !== null) {
+            attributes[key] = value;
+        }
+    }
+
+    return attributes;
+}
+
+function isChatDebugLogsEnabled(): boolean {
+    return process.env.CHAT_DEBUG_LOGS === 'true';
+}
 
 /**
  * Get all chat messages for a session.
@@ -156,28 +219,64 @@ export async function ensureChatSession(
     source: ConverseSource,
     userType?: UserType
 ): Promise<[ChatSession<RecordOrUndef>, boolean]> {
-    console.log('ensureChatSession called with:', {
-        userId: user.userId,
-        sessionId: requestData.sessionId,
-        agentId,
-        chatAppId,
-        simpleUser,
-        invocationMode,
-        entityEnabled,
-        entityValue,
-        userType
-    });
+    if (isChatDebugLogsEnabled()) {
+        console.log('ensureChatSession called with:', {
+            userId: user.userId,
+            sessionId: requestData.sessionId,
+            agentId,
+            chatAppId,
+            simpleUser,
+            invocationMode,
+            entityEnabled,
+            entityValue,
+            userType
+        });
+    }
 
     let isNewSession = false;
     let chatSession: ChatSession<RecordOrUndef> | undefined = requestData.sessionId ? await getChatSession(user.userId, requestData.sessionId) : undefined;
 
-    console.log('Existing session lookup result:', {
-        found: !!chatSession,
-        sessionId: requestData.sessionId
-    });
+    if (isChatDebugLogsEnabled()) {
+        console.log('Existing session lookup result:', {
+            found: !!chatSession,
+            sessionId: requestData.sessionId
+        });
+    }
+
+    if (chatSession) {
+        const customUserDataRecord = simpleUser.customUserData as Record<string, unknown> | undefined;
+        const backfillAttributes = getAccountBackfillAttributes(customUserDataRecord);
+
+        if (!hasSessionAccountContext(chatSession) && Object.keys(backfillAttributes).length > 0) {
+            try {
+                await mergeSessionAttributes(user.userId, chatSession.sessionId, backfillAttributes);
+                chatSession.sessionAttributes = {
+                    ...(chatSession.sessionAttributes ?? {}),
+                    ...backfillAttributes
+                };
+
+                if (isChatDebugLogsEnabled()) {
+                    console.log('ensureChatSession backfilled account context for existing session', {
+                        sessionId: chatSession.sessionId,
+                        userId: chatSession.userId,
+                        chatAppId: chatSession.chatAppId,
+                        backfilledKeys: Object.keys(backfillAttributes)
+                    });
+                }
+            } catch (error) {
+                console.warn('ensureChatSession failed to backfill account context', {
+                    sessionId: chatSession.sessionId,
+                    userId: chatSession.userId,
+                    error: error instanceof Error ? error.message : String(error)
+                });
+            }
+        }
+    }
 
     if (!chatSession) {
-        console.log('No existing session found, creating new session');
+        if (isChatDebugLogsEnabled()) {
+            console.log('No existing session found, creating new session');
+        }
 
         chatSession = await createChatSession({
             userId: user.userId,
@@ -201,22 +300,26 @@ export async function ensureChatSession(
             userType: userType ?? 'external-user'
         });
 
-        console.log('New session created:', {
-            sessionId: chatSession.sessionId,
-            userId: chatSession.userId,
-            chatAppId: chatSession.chatAppId,
-            agentId: chatSession.agentId,
-            entityId: chatSession.entityId
-        });
+        if (isChatDebugLogsEnabled()) {
+            console.log('New session created:', {
+                sessionId: chatSession.sessionId,
+                userId: chatSession.userId,
+                chatAppId: chatSession.chatAppId,
+                agentId: chatSession.agentId,
+                entityId: chatSession.entityId
+            });
+        }
 
         isNewSession = true;
     }
 
-    console.log('Returning session:', {
-        sessionId: chatSession.sessionId,
-        isNewSession,
-        lastUpdate: chatSession.lastUpdate
-    });
+    if (isChatDebugLogsEnabled()) {
+        console.log('Returning session:', {
+            sessionId: chatSession.sessionId,
+            isNewSession,
+            lastUpdate: chatSession.lastUpdate
+        });
+    }
 
     return [chatSession, isNewSession];
 }
@@ -258,6 +361,27 @@ export async function getChatSession(userId: string, sessionId: string): Promise
     const chatSession = await getChatSessionByUserIdAndSessionId(userId, sessionId);
     if (chatSession) {
         validateUserAgainstSession(chatSession, userId, sessionId);
+        try {
+            const sessionAttributes = chatSession.sessionAttributes as Record<string, unknown> | undefined;
+            if (isChatDebugLogsEnabled()) {
+                console.log('getChatSession debug:', {
+                    sessionId: chatSession.sessionId,
+                    userId: chatSession.userId,
+                    chatAppId: chatSession.chatAppId,
+                    entityId: chatSession.entityId ?? null,
+                    accountId: (chatSession as unknown as { accountId?: unknown }).accountId ?? null,
+                    sessionAttributesKeys: sessionAttributes ? Object.keys(sessionAttributes) : [],
+                    sessionAttributesAccountId: sessionAttributes?.accountId ?? sessionAttributes?.account_id ?? null,
+                    sessionAttributesAccount: sessionAttributes?.account ?? null,
+                    createDate: chatSession.createDate,
+                    lastUpdate: chatSession.lastUpdate
+                });
+            }
+        } catch (e) {
+            if (isChatDebugLogsEnabled()) {
+                console.warn('getChatSession: failed to log session debug', e);
+            }
+        }
     }
     return chatSession;
 }
@@ -277,22 +401,28 @@ export async function addChatMessage(
     userQuestionAsked?: string,
     answerToQuestionFromAgent?: string
 ): Promise<ChatMessage> {
-    console.log('addChatMessage called with:', {
-        sessionId: chatMessageForCreate.sessionId,
-        userId: chatMessageForCreate.userId,
-        source: chatMessageForCreate.source,
-        hasChatSession: !!chatSession,
-        hasUserQuestion: !!userQuestionAsked,
-        hasAgentAnswer: !!answerToQuestionFromAgent
-    });
+    if (isChatDebugLogsEnabled()) {
+        console.log('addChatMessage called with:', {
+            sessionId: chatMessageForCreate.sessionId,
+            userId: chatMessageForCreate.userId,
+            source: chatMessageForCreate.source,
+            hasChatSession: !!chatSession,
+            hasUserQuestion: !!userQuestionAsked,
+            hasAgentAnswer: !!answerToQuestionFromAgent
+        });
+    }
 
     if (!chatSession) {
-        console.log('No chat session provided, fetching from database');
+        if (isChatDebugLogsEnabled()) {
+            console.log('No chat session provided, fetching from database');
+        }
         chatSession = await getChatSession(chatMessageForCreate.userId, chatMessageForCreate.sessionId);
-        console.log('Fetched chat session:', {
-            found: !!chatSession,
-            sessionId: chatMessageForCreate.sessionId
-        });
+        if (isChatDebugLogsEnabled()) {
+            console.log('Fetched chat session:', {
+                found: !!chatSession,
+                sessionId: chatMessageForCreate.sessionId
+            });
+        }
     }
     if (!chatSession) {
         console.error('Chat session not found:', {
@@ -302,7 +432,9 @@ export async function addChatMessage(
         throw new UnauthorizedError(`Unauthorized: chat session not found: ${chatMessageForCreate.sessionId}`);
     }
 
-    console.log('Validating user against session');
+    if (isChatDebugLogsEnabled()) {
+        console.log('Validating user against session');
+    }
     if (chatMessageForCreate.userId !== 'assistant') {
         // Only validate the user against the session if the user is not the assistant adding the message
         validateUserAgainstSession(chatSession, chatMessageForCreate.userId, chatMessageForCreate.sessionId);
@@ -317,47 +449,61 @@ export async function addChatMessage(
         userType: chatSession.userType || 'internal-user'
     };
 
-    console.log('Created chat message:', {
-        messageId: chatMessage.messageId,
-        timestamp: chatMessage.timestamp,
-        lastMessageId: chatSession.lastMessageId
-    });
+    if (isChatDebugLogsEnabled()) {
+        console.log('Created chat message:', {
+            messageId: chatMessage.messageId,
+            timestamp: chatMessage.timestamp,
+            lastMessageId: chatSession.lastMessageId
+        });
+    }
 
-    console.log('Adding message and updating session in parallel');
+    if (isChatDebugLogsEnabled()) {
+        console.log('Adding message and updating session in parallel');
+    }
     await Promise.all([
         addMessage(chatMessage),
         updateSession(chatMessage.sessionId, chatSession.userId, chatMessage.messageId, chatMessage.timestamp, chatMessage.usage, chatSession.chatAppId, chatSession.source)
     ]);
-    console.log('Message added and session updated');
+    if (isChatDebugLogsEnabled()) {
+        console.log('Message added and session updated');
+    }
 
     // Update the local object with the new message id and update timestamp
     chatSession.lastMessageId = chatMessage.messageId;
     chatSession.lastUpdate = chatMessage.timestamp;
-    console.log('Local session object updated:', {
-        lastMessageId: chatSession.lastMessageId,
-        lastUpdate: chatSession.lastUpdate
-    });
+    if (isChatDebugLogsEnabled()) {
+        console.log('Local session object updated:', {
+            lastMessageId: chatSession.lastMessageId,
+            lastUpdate: chatSession.lastUpdate
+        });
+    }
 
     if (userQuestionAsked && answerToQuestionFromAgent && chatSession.title == null) {
         try {
-            console.log('Updating session title with Bedrock');
+            if (isChatDebugLogsEnabled()) {
+                console.log('Updating session title with Bedrock');
+            }
             const sessionResponse = await updateSessionTitle(chatMessageForCreate.sessionId, chatMessageForCreate.userId, {
                 userId: chatMessageForCreate.userId,
                 userQuestionAsked: userQuestionAsked,
                 answerToQuestionFromAgent: answerToQuestionFromAgent
             });
             chatSession.title = sessionResponse.session.title;
-            console.log('Session title updated:', chatSession.title);
+            if (isChatDebugLogsEnabled()) {
+                console.log('Session title updated:', chatSession.title);
+            }
         } catch (error) {
             console.error('Failed to generate session title (non-fatal):', error instanceof Error ? error.message : error);
         }
     }
 
-    console.log('Returning chat message:', {
-        messageId: chatMessage.messageId,
-        timestamp: chatMessage.timestamp,
-        source: chatMessage.source
-    });
+    if (isChatDebugLogsEnabled()) {
+        console.log('Returning chat message:', {
+            messageId: chatMessage.messageId,
+            timestamp: chatMessage.timestamp,
+            source: chatMessage.source
+        });
+    }
     return chatMessage;
 }
 

--- a/services/pika/src/lib/chat-ddb.ts
+++ b/services/pika/src/lib/chat-ddb.ts
@@ -58,6 +58,10 @@ const ddbDocClient = DynamoDBDocument.from(ddbClient, {
     }
 });
 
+function isChatDebugLogsEnabled(): boolean {
+    return process.env.CHAT_DEBUG_LOGS === 'true';
+}
+
 export async function searchForUsersByPartialUserId(partialUserId: string): Promise<ChatUserLite[]> {
     const users = await ddbDocClient.query({
         TableName: getChatUserTable(),
@@ -181,7 +185,9 @@ export async function addUser(user: ChatUser<RecordOrUndef>): Promise<ChatUser<R
     (user as any).userIdPrefix = user.userId.slice(0, 3).toLowerCase(); // Used as partition key for the GSI.
     (user as any).userIdLower = user.userId.toLowerCase(); // This is used for case insensitive searches.
 
-    console.log('about to add user in chat database', convertChatUserToSnakeFromCamelCase(user));
+    if (isChatDebugLogsEnabled()) {
+        console.log('about to add user in chat database', convertChatUserToSnakeFromCamelCase(user));
+    }
 
     await ddbDocClient.put({
         TableName: getChatUserTable(),
@@ -321,11 +327,63 @@ export async function getChatSessionByUserIdAndSessionId(userId: string, session
         }
     });
 
+    try {
+        const item = session.Item as Record<string, unknown> | undefined;
+        if (isChatDebugLogsEnabled()) {
+            console.log('getChatSessionByUserIdAndSessionId raw item debug:', {
+                userId,
+                sessionId,
+                found: !!item,
+                itemKeys: item ? Object.keys(item) : [],
+                entityId: item?.entity_id ?? item?.entityId ?? null,
+                accountId: item?.account_id ?? item?.accountId ?? null,
+                sessionAttributesKeys: item?.session_attributes && typeof item.session_attributes === 'object' && !Array.isArray(item.session_attributes)
+                    ? Object.keys(item.session_attributes as Record<string, unknown>)
+                    : [],
+                sessionAttributesAccountId:
+                    item?.session_attributes && typeof item.session_attributes === 'object' && !Array.isArray(item.session_attributes)
+                        ? (item.session_attributes as Record<string, unknown>).account_id ??
+                            (item.session_attributes as Record<string, unknown>).accountId ??
+                            null
+                        : null,
+                sessionAttributesAccount:
+                    item?.session_attributes && typeof item.session_attributes === 'object' && !Array.isArray(item.session_attributes)
+                        ? (item.session_attributes as Record<string, unknown>).account ?? null
+                        : null
+            });
+        }
+    } catch (error) {
+        if (isChatDebugLogsEnabled()) {
+            console.warn('getChatSessionByUserIdAndSessionId: failed to log raw item debug', error);
+        }
+    }
+
     return session.Item ? convertChatSessionToCamelFromSnakeCase<RecordOrUndef>(session.Item as SnakeCase<ChatSession<RecordOrUndef>>) : undefined;
 }
 
 export async function addChatSession(chatSession: ChatSession<RecordOrUndef>): Promise<ChatSession<RecordOrUndef>> {
     const item = convertChatSessionToSnakeFromCamelCase<RecordOrUndef>(chatSession);
+
+    try {
+        const sessionAttributes = (item as Record<string, unknown>).session_attributes as Record<string, unknown> | undefined;
+        if (isChatDebugLogsEnabled()) {
+            console.log('addChatSession raw item debug:', {
+                sessionId: chatSession.sessionId,
+                userId: chatSession.userId,
+                chatAppId: chatSession.chatAppId,
+                itemKeys: Object.keys(item as Record<string, unknown>),
+                entityId: (item as Record<string, unknown>).entity_id ?? (item as Record<string, unknown>).entityId ?? null,
+                accountId: (item as Record<string, unknown>).account_id ?? (item as Record<string, unknown>).accountId ?? null,
+                sessionAttributesKeys: sessionAttributes ? Object.keys(sessionAttributes) : [],
+                sessionAttributesAccountId: sessionAttributes?.account_id ?? sessionAttributes?.accountId ?? null,
+                sessionAttributesAccount: sessionAttributes?.account ?? null
+            });
+        }
+    } catch (error) {
+        if (isChatDebugLogsEnabled()) {
+            console.warn('addChatSession: failed to log raw item debug', error);
+        }
+    }
 
     // Default source to 'user' if not present
     const source = chatSession.source || 'user';
@@ -449,6 +507,54 @@ export async function updateSession(
                                output_cost :outputCost,
                                output_tokens :outputTokens,
                                total_cost :totalCost`,
+        ExpressionAttributeValues: expressionAttributeValues
+    });
+}
+
+/**
+ * Merges additional key-value pairs into the `session_attributes` map of an existing session.
+ * Safely initialises `session_attributes` to an empty map if it does not yet exist, then
+ * writes each attribute individually to avoid overwriting unrelated keys.
+ *
+ * @param userId - Owner of the session
+ * @param sessionId - Session to update
+ * @param attributes - Key-value pairs to merge into sessionAttributes
+ */
+export async function mergeSessionAttributes(userId: string, sessionId: string, attributes: Record<string, unknown>): Promise<void> {
+    if (Object.keys(attributes).length === 0) {
+        return;
+    }
+
+    const setExpressions: string[] = [];
+    const expressionAttributeNames: Record<string, string> = {
+        '#sessionAttributes': 'session_attributes'
+    };
+    const expressionAttributeValues: Record<string, unknown> = {};
+
+    let i = 0;
+    for (const [key, value] of Object.entries(attributes)) {
+        const nameKey = `#k${i}`;
+        const valueKey = `:v${i}`;
+        expressionAttributeNames[nameKey] = key;
+        expressionAttributeValues[valueKey] = value;
+        setExpressions.push(`#sessionAttributes.${nameKey} = ${valueKey}`);
+        i += 1;
+    }
+
+    // Ensure session_attributes map exists before setting nested keys
+    await ddbDocClient.update({
+        TableName: getChatSessionTable(),
+        Key: { user_id: userId, session_id: sessionId },
+        UpdateExpression: 'SET #sessionAttributes = if_not_exists(#sessionAttributes, :emptyMap)',
+        ExpressionAttributeNames: { '#sessionAttributes': 'session_attributes' },
+        ExpressionAttributeValues: { ':emptyMap': {} }
+    });
+
+    await ddbDocClient.update({
+        TableName: getChatSessionTable(),
+        Key: { user_id: userId, session_id: sessionId },
+        UpdateExpression: `SET ${setExpressions.join(', ')}`,
+        ExpressionAttributeNames: expressionAttributeNames,
         ExpressionAttributeValues: expressionAttributeValues
     });
 }

--- a/services/pika/src/lib/utils.ts
+++ b/services/pika/src/lib/utils.ts
@@ -323,9 +323,87 @@ export function convertChatSessionToCamelFromSnakeCase<T extends RecordOrUndef =
 
 const DEFAULT_ACCOUNT_ID_FIELD_NAMES = ['accountId', 'account_id'];
 
-function getAccountIdFieldNames(): string[] {
+/**
+ * Returns the list of field names used to resolve an account ID from session data.
+ * Reads from the `PIKA_ACCOUNT_ID_FIELD_NAMES` environment variable (comma-separated).
+ * Falls back to `['accountId', 'account_id']` when the env var is not set.
+ */
+export function getAccountIdFieldNames(): string[] {
     const envVal = process.env.PIKA_ACCOUNT_ID_FIELD_NAMES;
     return envVal ? envVal.split(',').map((s) => s.trim()).filter(Boolean) : DEFAULT_ACCOUNT_ID_FIELD_NAMES;
+}
+
+/**
+ * Returns true when the session already carries an account ID in any recognised field,
+ * so the backfill step can be skipped for existing sessions.
+ * Checks top-level fields, sessionAttributes fields, and the nested `account` object.
+ * Uses `getAccountIdFieldNames()` so `PIKA_ACCOUNT_ID_FIELD_NAMES` controls resolution.
+ */
+export function hasSessionAccountContext(session: ChatSession<RecordOrUndef>): boolean {
+    const fieldNames = getAccountIdFieldNames();
+    const sessionRecord = session as unknown as Record<string, unknown>;
+
+    // Check top-level fields first
+    for (const field of fieldNames) {
+        const v = sessionRecord[field];
+        if (typeof v === 'string' && v.length > 0) return true;
+        if (typeof v === 'number') return true;
+    }
+
+    const sessionAttributes = (sessionRecord.sessionAttributes as Record<string, unknown> | undefined) ?? undefined;
+
+    // Check sessionAttributes fields
+    if (sessionAttributes) {
+        for (const field of fieldNames) {
+            const v = sessionAttributes[field];
+            if (typeof v === 'string' && v.length > 0) return true;
+            if (typeof v === 'number') return true;
+        }
+    }
+
+    // Fall back to nested account object (account.id, account.accountId, account.account_id)
+    const accountObject = sessionAttributes?.account;
+    if (accountObject && typeof accountObject === 'object' && !Array.isArray(accountObject)) {
+        const accountRecord = accountObject as Record<string, unknown>;
+        const nestedId = accountRecord.id ?? accountRecord.accountId ?? accountRecord.account_id;
+        if (typeof nestedId === 'string' && nestedId.length > 0) return true;
+        if (typeof nestedId === 'number') return true;
+    }
+
+    return false;
+}
+
+/**
+ * Extracts the subset of user customData fields that are relevant to account context,
+ * for backfilling onto sessions that don't yet have an account ID.
+ * Includes all `getAccountIdFieldNames()` fields plus static metadata keys and the
+ * nested `account` object.
+ */
+export function getAccountBackfillAttributes(customUserData: Record<string, unknown> | undefined): Record<string, unknown> {
+    if (!customUserData) {
+        return {};
+    }
+
+    // Start with dynamic account ID field names (e.g. accountId, account_id, retailerId, supplierId, etc.)
+    // then append the static metadata fields and the nested account object.
+    const allowedKeys = [
+        ...getAccountIdFieldNames(),
+        'accountType',
+        'account_type',
+        'accountName',
+        'account_name',
+        'account'
+    ];
+
+    const attributes: Record<string, unknown> = {};
+    for (const key of allowedKeys) {
+        const value = customUserData[key];
+        if (value !== undefined && value !== null) {
+            attributes[key] = value;
+        }
+    }
+
+    return attributes;
 }
 
 /**

--- a/services/pika/src/lib/utils.ts
+++ b/services/pika/src/lib/utils.ts
@@ -311,7 +311,65 @@ export function convertChatSessionToCamelFromSnakeCase<T extends RecordOrUndef =
         );
     }
 
+    // Normalize account ID onto the top-level session row for admin tables.
+    const sessionAttributes = (converted as any).sessionAttributes as Record<string, unknown> | undefined;
+    const normalizedAccountId = getNormalizedAccountId(sessionAttributes);
+    if (normalizedAccountId) {
+        (converted as any).accountId = normalizedAccountId;
+    }
+
     return converted as ChatSession<T>;
+}
+
+const DEFAULT_ACCOUNT_ID_FIELD_NAMES = ['accountId', 'account_id'];
+
+function getAccountIdFieldNames(): string[] {
+    const envVal = process.env.PIKA_ACCOUNT_ID_FIELD_NAMES;
+    return envVal ? envVal.split(',').map((s) => s.trim()).filter(Boolean) : DEFAULT_ACCOUNT_ID_FIELD_NAMES;
+}
+
+/**
+ * Extracts a normalized account ID string from a session-attributes object.
+ * Tries each field name in `accountIdFieldNames` (top-level keys first, then
+ * the nested `account` sub-object's `id`/`accountId`/`account_id` fields).
+ *
+ * @param sessionAttributes - The session attributes record to inspect
+ * @param accountIdFieldNames - Field names to try, in order. Defaults to `PIKA_ACCOUNT_ID_FIELD_NAMES`
+ *   env var value, or `['accountId', 'account_id']` if not set.
+ * @returns The first non-empty string (or stringified number) found, or undefined
+ */
+function getNormalizedAccountId(
+    sessionAttributes: Record<string, unknown> | undefined,
+    accountIdFieldNames: string[] = getAccountIdFieldNames()
+): string | undefined {
+    if (!sessionAttributes) {
+        return undefined;
+    }
+
+    for (const fieldName of accountIdFieldNames) {
+        const rawValue = sessionAttributes[fieldName];
+        if (typeof rawValue === 'string' && rawValue.length > 0) {
+            return rawValue;
+        }
+        if (typeof rawValue === 'number') {
+            return String(rawValue);
+        }
+    }
+
+    // Fall back to nested account object (account.id, account.accountId, account.account_id)
+    const accountObject = sessionAttributes.account;
+    if (accountObject && typeof accountObject === 'object' && !Array.isArray(accountObject)) {
+        const accountRecord = accountObject as Record<string, unknown>;
+        const nestedAccountId = accountRecord.id ?? accountRecord.accountId ?? accountRecord.account_id;
+        if (typeof nestedAccountId === 'string' && nestedAccountId.length > 0) {
+            return nestedAccountId;
+        }
+        if (typeof nestedAccountId === 'number') {
+            return String(nestedAccountId);
+        }
+    }
+
+    return undefined;
 }
 
 /**

--- a/services/pika/test/lib/utils-account-normalization.test.ts
+++ b/services/pika/test/lib/utils-account-normalization.test.ts
@@ -1,4 +1,4 @@
-import { convertChatSessionToCamelFromSnakeCase } from '../../src/lib/utils';
+import { convertChatSessionToCamelFromSnakeCase, getAccountBackfillAttributes, hasSessionAccountContext } from '../../src/lib/utils';
 
 /** Minimal snake_case session for testing account-normalization logic only. */
 function makeSession(sessionAttributes?: Record<string, unknown>): any {
@@ -131,5 +131,163 @@ describe('convertChatSessionToCamelFromSnakeCase — account ID normalization', 
             const result = convertChatSessionToCamelFromSnakeCase(makeSession({ supplierId: 'sup-2' }));
             expect((result as any).accountId).toBe('sup-2');
         });
+    });
+});
+
+// ─── helpers for chat-apis tests ────────────────────────────────────────────
+
+/** Minimal camelCase ChatSession for hasSessionAccountContext. */
+function makeChatSession(overrides: Record<string, unknown> = {}, sessionAttributesOverrides?: Record<string, unknown>): any {
+    const base: Record<string, unknown> = {
+        sessionId: 'sess-1',
+        userId: 'user-1',
+        agentId: 'agent-1',
+        chatAppId: 'app-1',
+        identityId: 'id-1',
+        invocationMode: 'chat',
+        createDate: '2024-01-01T00:00:00Z',
+        lastUpdate: '2024-01-01T00:00:00Z',
+        entityId: 'ent-1',
+        ...overrides
+    };
+    if (sessionAttributesOverrides !== undefined) {
+        base.sessionAttributes = {
+            userId: 'user-1',
+            chatAppId: 'app-1',
+            agentId: 'agent-1',
+            currentDate: '2024-01-01',
+            ...sessionAttributesOverrides
+        };
+    }
+    return base;
+}
+
+// ─── hasSessionAccountContext ────────────────────────────────────────────────
+
+describe('hasSessionAccountContext', () => {
+    const originalEnv = process.env.PIKA_ACCOUNT_ID_FIELD_NAMES;
+
+    afterEach(() => {
+        if (originalEnv === undefined) {
+            delete process.env.PIKA_ACCOUNT_ID_FIELD_NAMES;
+        } else {
+            process.env.PIKA_ACCOUNT_ID_FIELD_NAMES = originalEnv;
+        }
+    });
+
+    describe('default field names (accountId, account_id)', () => {
+        it('returns true when top-level accountId is set', () => {
+            expect(hasSessionAccountContext(makeChatSession({ accountId: 'acc-1' }))).toBe(true);
+        });
+
+        it('returns true when top-level account_id is set', () => {
+            expect(hasSessionAccountContext(makeChatSession({ account_id: 'acc-2' }))).toBe(true);
+        });
+
+        it('returns true when sessionAttributes.accountId is set', () => {
+            expect(hasSessionAccountContext(makeChatSession({}, { accountId: 'attr-acc' }))).toBe(true);
+        });
+
+        it('returns true when sessionAttributes.account_id is set', () => {
+            expect(hasSessionAccountContext(makeChatSession({}, { account_id: 'attr-acc' }))).toBe(true);
+        });
+
+        it('returns false when no account fields are present', () => {
+            expect(hasSessionAccountContext(makeChatSession({}, { someField: 'value' }))).toBe(false);
+        });
+
+        it('returns false when session has no sessionAttributes', () => {
+            expect(hasSessionAccountContext(makeChatSession())).toBe(false);
+        });
+
+        it('returns true via nested account.id fallback', () => {
+            expect(hasSessionAccountContext(makeChatSession({}, { account: { id: 'nested-1' } }))).toBe(true);
+        });
+    });
+
+    describe('legacy field names (retailerId, supplierId, etc.)', () => {
+        it('returns true when top-level retailerId is set (default field names)', () => {
+            // With default field names, retailerId is NOT included — should return false
+            delete process.env.PIKA_ACCOUNT_ID_FIELD_NAMES;
+            expect(hasSessionAccountContext(makeChatSession({ retailerId: 'ret-1' }))).toBe(false);
+        });
+
+        it('returns true when top-level retailerId is set with PIKA_ACCOUNT_ID_FIELD_NAMES override', () => {
+            process.env.PIKA_ACCOUNT_ID_FIELD_NAMES = 'accountId,account_id,retailerId,retailer_id,supplierId,supplier_id,actingAsAccountId,acting_as_account_id';
+            expect(hasSessionAccountContext(makeChatSession({ retailerId: 'ret-1' }))).toBe(true);
+        });
+
+        it('returns true when sessionAttributes.supplierId is set with PIKA_ACCOUNT_ID_FIELD_NAMES override', () => {
+            process.env.PIKA_ACCOUNT_ID_FIELD_NAMES = 'accountId,account_id,retailerId,retailer_id,supplierId,supplier_id';
+            expect(hasSessionAccountContext(makeChatSession({}, { supplierId: 'sup-42' }))).toBe(true);
+        });
+
+        it('returns true when top-level actingAsAccountId is set with PIKA_ACCOUNT_ID_FIELD_NAMES override', () => {
+            process.env.PIKA_ACCOUNT_ID_FIELD_NAMES = 'accountId,account_id,actingAsAccountId,acting_as_account_id';
+            expect(hasSessionAccountContext(makeChatSession({ actingAsAccountId: 'act-5' }))).toBe(true);
+        });
+    });
+});
+
+// ─── getAccountBackfillAttributes ───────────────────────────────────────────
+
+describe('getAccountBackfillAttributes', () => {
+    const originalEnv = process.env.PIKA_ACCOUNT_ID_FIELD_NAMES;
+
+    afterEach(() => {
+        if (originalEnv === undefined) {
+            delete process.env.PIKA_ACCOUNT_ID_FIELD_NAMES;
+        } else {
+            process.env.PIKA_ACCOUNT_ID_FIELD_NAMES = originalEnv;
+        }
+    });
+
+    it('returns empty object for undefined input', () => {
+        expect(getAccountBackfillAttributes(undefined)).toEqual({});
+    });
+
+    it('picks up accountId and accountType with default field names', () => {
+        const result = getAccountBackfillAttributes({ accountId: 'acc-1', accountType: 'retailer', irrelevant: 'drop-me' });
+        expect(result).toEqual({ accountId: 'acc-1', accountType: 'retailer' });
+        expect(result).not.toHaveProperty('irrelevant');
+    });
+
+    it('picks up account_id and account_name with default field names', () => {
+        const result = getAccountBackfillAttributes({ account_id: 'acc-2', account_name: 'Acme' });
+        expect(result).toEqual({ account_id: 'acc-2', account_name: 'Acme' });
+    });
+
+    it('picks up nested account object', () => {
+        const result = getAccountBackfillAttributes({ account: { id: 'nested-1' } });
+        expect(result).toEqual({ account: { id: 'nested-1' } });
+    });
+
+    it('does NOT pick up retailerId with default field names', () => {
+        delete process.env.PIKA_ACCOUNT_ID_FIELD_NAMES;
+        const result = getAccountBackfillAttributes({ retailerId: 'ret-1', accountId: 'acc-1' });
+        expect(result).toHaveProperty('accountId', 'acc-1');
+        expect(result).not.toHaveProperty('retailerId');
+    });
+
+    it('picks up retailerId when included in PIKA_ACCOUNT_ID_FIELD_NAMES', () => {
+        process.env.PIKA_ACCOUNT_ID_FIELD_NAMES = 'accountId,account_id,retailerId,retailer_id,supplierId,supplier_id,actingAsAccountId,acting_as_account_id';
+        const result = getAccountBackfillAttributes({
+            retailerId: 'ret-99',
+            supplierId: 'sup-99',
+            actingAsAccountId: 'act-99',
+            accountType: 'retailer',
+            irrelevant: 'drop-me'
+        });
+        expect(result).toHaveProperty('retailerId', 'ret-99');
+        expect(result).toHaveProperty('supplierId', 'sup-99');
+        expect(result).toHaveProperty('actingAsAccountId', 'act-99');
+        expect(result).toHaveProperty('accountType', 'retailer');
+        expect(result).not.toHaveProperty('irrelevant');
+    });
+
+    it('omits null values', () => {
+        const result = getAccountBackfillAttributes({ accountId: null as any, account_id: 'acc-3' });
+        expect(result).not.toHaveProperty('accountId');
+        expect(result).toHaveProperty('account_id', 'acc-3');
     });
 });

--- a/services/pika/test/lib/utils-account-normalization.test.ts
+++ b/services/pika/test/lib/utils-account-normalization.test.ts
@@ -1,0 +1,135 @@
+import { convertChatSessionToCamelFromSnakeCase } from '../../src/lib/utils';
+
+/** Minimal snake_case session for testing account-normalization logic only. */
+function makeSession(sessionAttributes?: Record<string, unknown>): any {
+    return {
+        session_id: 'sess-1',
+        user_id: 'user-1',
+        agent_id: 'agent-1',
+        chat_app_id: 'app-1',
+        identity_id: 'id-1',
+        invocation_mode: 'chat',
+        create_date: '2024-01-01T00:00:00Z',
+        last_update: '2024-01-01T00:00:00Z',
+        entity_id: 'ent-1',
+        ...(sessionAttributes !== undefined && { session_attributes: { user_id: 'user-1', chat_app_id: 'app-1', agent_id: 'agent-1', current_date: '2024-01-01', ...sessionAttributes } })
+    };
+}
+
+describe('convertChatSessionToCamelFromSnakeCase — account ID normalization', () => {
+    const originalEnv = process.env.PIKA_ACCOUNT_ID_FIELD_NAMES;
+
+    afterEach(() => {
+        if (originalEnv === undefined) {
+            delete process.env.PIKA_ACCOUNT_ID_FIELD_NAMES;
+        } else {
+            process.env.PIKA_ACCOUNT_ID_FIELD_NAMES = originalEnv;
+        }
+    });
+
+    describe('default field names (accountId, account_id)', () => {
+        it('projects accountId string onto top-level', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ accountId: 'acc-123' }));
+            expect((result as any).accountId).toBe('acc-123');
+        });
+
+        it('projects account_id string onto top-level', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ account_id: 'acc-456' }));
+            expect((result as any).accountId).toBe('acc-456');
+        });
+
+        it('prefers accountId over account_id when both present', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ accountId: 'camel', account_id: 'snake' }));
+            expect((result as any).accountId).toBe('camel');
+        });
+
+        it('stringifies a numeric accountId', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ accountId: 42 }));
+            expect((result as any).accountId).toBe('42');
+        });
+
+        it('stringifies a numeric account_id', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ account_id: 99 }));
+            expect((result as any).accountId).toBe('99');
+        });
+
+        it('does not project an empty string accountId', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ accountId: '' }));
+            expect((result as any).accountId).toBeUndefined();
+        });
+
+        it('does not set accountId when no account fields are present', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ someOtherField: 'value' }));
+            expect((result as any).accountId).toBeUndefined();
+        });
+
+        it('does not set accountId when session_attributes is absent', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession());
+            expect((result as any).accountId).toBeUndefined();
+        });
+    });
+
+    describe('nested account object fallback', () => {
+        it('projects account.id when top-level fields are absent', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ account: { id: 'nested-id' } }));
+            expect((result as any).accountId).toBe('nested-id');
+        });
+
+        it('projects account.accountId when top-level fields are absent', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ account: { accountId: 'nested-camel' } }));
+            expect((result as any).accountId).toBe('nested-camel');
+        });
+
+        it('projects account.account_id when top-level fields are absent', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ account: { account_id: 'nested-snake' } }));
+            expect((result as any).accountId).toBe('nested-snake');
+        });
+
+        it('stringifies a numeric account.id', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ account: { id: 7 } }));
+            expect((result as any).accountId).toBe('7');
+        });
+
+        it('top-level accountId takes precedence over nested account.id', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ accountId: 'top', account: { id: 'nested' } }));
+            expect((result as any).accountId).toBe('top');
+        });
+
+        it('does not project when account object has no id field', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ account: { name: 'Acme' } }));
+            expect((result as any).accountId).toBeUndefined();
+        });
+
+        it('does not project when account is an array (not an object)', () => {
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ account: ['acc-1'] }));
+            expect((result as any).accountId).toBeUndefined();
+        });
+    });
+
+    describe('PIKA_ACCOUNT_ID_FIELD_NAMES env override', () => {
+        it('uses a custom single field name', () => {
+            process.env.PIKA_ACCOUNT_ID_FIELD_NAMES = 'retailerId';
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ retailerId: 'ret-789' }));
+            expect((result as any).accountId).toBe('ret-789');
+        });
+
+        it('uses multiple custom field names in order', () => {
+            process.env.PIKA_ACCOUNT_ID_FIELD_NAMES = 'supplierId,retailerId';
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ retailerId: 'ret-1', supplierId: 'sup-1' }));
+            expect((result as any).accountId).toBe('sup-1');
+        });
+
+        it('ignores default field names when env override is set', () => {
+            process.env.PIKA_ACCOUNT_ID_FIELD_NAMES = 'retailerId';
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ accountId: 'default-name', retailerId: 'custom-name' }));
+            // custom field wins because accountId is not in the override list
+            expect((result as any).accountId).toBe('custom-name');
+        });
+
+        it('trims whitespace around field names in env var', () => {
+            process.env.PIKA_ACCOUNT_ID_FIELD_NAMES = ' retailerId , supplierId ';
+            const result = convertChatSessionToCamelFromSnakeCase(makeSession({ supplierId: 'sup-2' }));
+            expect((result as any).accountId).toBe('sup-2');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- **Debug instrumentation** (`CHAT_DEBUG_LOGS` env var): All verbose `console.log` calls in `chat-apis.ts` and `chat-ddb.ts` are now gated behind `isChatDebugLogsEnabled()`. Adds raw-item debug blocks to `getChatSessionByUserIdAndSessionId` and `addChatSession` in the DDB layer.
- **Account backfill in `ensureChatSession`**: When an existing session lacks account context and the user's `customUserData` contains account fields, they are patched onto `sessionAttributes` via a new `mergeSessionAttributes` DDB utility.
- **`batchGetUserCustomDataByUserIds`**: Batch DDB fetch (100/page, p-retry) that returns `Map<userId, customData>`. Used by `searchForSessions` account enrichment.
- **`searchForSessions` account enrichment**: Sessions returned by admin search that are missing top-level `accountId` and session-attributes `accountId` are enriched by fetching user customData from DDB. Non-fatal — failures are logged as warnings.
- **`getNormalizedAccountId` in `utils.ts`**: Projects account ID onto the top-level session row during `convertChatSessionToCamelFromSnakeCase`. Reads field names from `PIKA_ACCOUNT_ID_FIELD_NAMES` env var (default `['accountId', 'account_id']`).
- **`PikaConfig.accountIdFieldNames`**: New optional config field wired through CDK to all three lambdas (chatbot API, chat-admin API, converse).
- **Docs**: `environment-variables.mdoc` + `platform-settings.mdoc` updated for `CHAT_DEBUG_LOGS` and `accountIdFieldNames`.

## Task Reference

- Jira: https://chb.atlassian.net/browse/ES-3130

## Files Modified

| File | Change |
|------|--------|
| `packages/shared/src/types/chatbot/chatbot-types.ts` | Add `PikaConfig.accountIdFieldNames` |
| `services/pika/lib/constructs/pika-construct.ts` | Add `accountIdFieldNames` to props + lambda env vars |
| `services/pika/lib/stacks/pika-stack.ts` | Pass `pikaConfig.accountIdFieldNames` to construct |
| `services/pika/src/lib/utils.ts` | Add `getNormalizedAccountId`, call from session conversion |
| `services/pika/src/lib/chat-ddb.ts` | `isChatDebugLogsEnabled`, 2 debug blocks, `mergeSessionAttributes` |
| `services/pika/src/lib/chat-apis.ts` | 4 helpers, gate all logs, account backfill in `ensureChatSession` |
| `services/pika/src/lib/chat-admin-ddb.ts` | `batchGetUserCustomDataByUserIds` |
| `services/pika/src/lib/chat-admin-apis.ts` | `searchForSessions` account enrichment, 3 helper fns |
| `apps/pika-docs/…/environment-variables.mdoc` | `CHAT_DEBUG_LOGS` + `PIKA_ACCOUNT_ID_FIELD_NAMES` docs |
| `apps/pika-docs/…/platform-settings.mdoc` | `accountIdFieldNames` config docs |

## Testing

- `pnpm --filter pika test` — 112 tests, all pass
- `npx tsc --noEmit` (pika service) — no type errors
- `pnpm --filter pika-shared build` — clean

## Decision Log

- **`mergeSessionAttributes` added**: Not in pika yet; ported from ai-bot since account-backfill in `ensureChatSession` requires it. Follows identical DDB update pattern.
- **`hasSessionAccountContext` uses default field names only**: The helper in `chat-apis.ts` checks only `accountId`/`account_id` (not consumer-specific names) to avoid pulling `PikaConfig` into the API layer at runtime. This is intentional — the backfill falls back gracefully if these fields aren't present.
- **`extractTopLevelAccountId/SessionAttributesAccountId` helpers in `chat-admin-apis.ts` also check only canonical names**: Same rationale. Consumers with extra field names will have already had them projected onto `accountId` by `getNormalizedAccountId` during session conversion, so the canonical check is sufficient here.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Tests pass (112/112)
- [x] TypeScript clean
- [x] Documentation updated
- [x] Default behavior preserves existing pika behavior 1:1