### PR TITLE
chore(release): v0.26.0 — CM-491 framework seams, demo-mode hooks, Strands memory, services library, sync v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to the Pika Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.0] - 2026-05-26
+
+### Added
+
+- **CM-491 framework seams — 11 AzureAD-friendly extension-point hooks** in `apps/pika-chat/src/lib/custom/`. Covers admin gating (`isUserAllowedAdminAccess` in `site-admin.ts`), legacy session loading (`loadLegacyChatsIfNeeded`, `getLegacyChatsSectionHeader`, `getLegacyChatsSectionTrigger`), session permissions (`isCurrentSessionReadOnly`), legacy-user-id validation (`validateLegacyUserIdIfNeeded`), entity extraction (`getSessionEntityValue`), session account-context transformation (`transformSessionAccountContext`), ChatUser role-merge bypass (`shouldBypassChatUserRoleMerge`), and auth-provider hooks (`onAuthProviderCallback`, `onBeforeAuth` in `server-hooks.ts`). All hooks default to no-op so existing deployments are unaffected. New `lib/custom/README.md` Extension Points section and pika-docs [Extension Points guide](/guides/customization/extension-points/). [#147]
+- **Demo-mode framework seams — 7 hooks + public CSS contract** in `apps/pika-chat/src/lib/custom/`: `getDemoBannerComponent` (banner slot), `getDemoModeMenuItem` (menu-item slot wired into 4 user dropdowns), `getUserRefreshIntervalMs` (polling cadence), `isInternalUser` (effective-user predicate), `resolveUserForHomeChatApps` (home-page chat-app filter), `shouldShowLogout` (Logout-item visibility in chat/admin/nav dropdowns), `shouldShowDetailedTrace` (detailed-trace UI gate). Public CSS contract via `--demo-banner-h` custom property reserves viewport space when a banner is mounted (5 selectors in `app.css` subtract banner height from `100svh`/`100vh` containers). Defaults preserve current behavior. New pika-docs [Demo-Mode Hooks guide](/guides/customization/demo-mode-hooks/). [#146]
+- **Strands-native long-term user memory** in the Python `converseStrands` Lambda. Agent-driven retrieval (`agent_core_memory.retrieve`) and explicit save (`record`) replace the legacy TypeScript Lambda's per-turn `CreateEventCommand` writes. Two-layer design preserves Bedrock prompt cache: `MEMORY_SYSTEM_PROMPT_ADDITION` describes capability in the shared system prompt; `NEW_SESSION_MEMORY_NUDGE` appends a lightweight retrieval trigger to the first user message of a new session only. Opt in via `agent_def.memory_feature.enabled = true` with a non-empty `memory_id` from AgentCore. New pika-docs [Strands Long-Term User Memory guide](/guides/advanced/strands-memory/). [#152]
+- **Services library account-context utilities** in `services/pika/src/lib/`:
+  - `batchGetUserCustomDataByUserIds()` — batched DDB BatchGet (size 100) with `p-retry` for admin enrichment paths
+  - `getAccountIdFieldNames()` / `getNormalizedAccountId()` / `hasSessionAccountContext()` / `getAccountBackfillAttributes()` — configurable account-ID resolution honoring `PIKA_ACCOUNT_ID_FIELD_NAMES` env var and `PikaConfig.accountIdFieldNames`
+  - `mergeSessionAttributes()` — DDB session-attribute merge helper used by admin search enrichment
+  - `CHAT_DEBUG_LOGS` env var gates noisy chat-API debug logs
+  - New `PikaConfig.accountIdFieldNames` option (defaults to `['accountId', 'account_id']`) wired into the `PIKA_ACCOUNT_ID_FIELD_NAMES` Lambda environment on all 3 converse-handler Lambda definitions in `PikaConstruct` [#149]
+
+### Changed
+
+- **Default `pika sync` `protectedAreas` expanded to v1.0.6** — 9 new default-protected paths cover account/entity integration extension points (`custom-shared-types.ts`, `custom-site-features.ts`, legacy session endpoint, custom-account-search-api, AzureAD callback route, `apps/pika-chat/tools/custom-*/**`), CDK stack-def files (`apps/pika-chat/infra/lib/stacks/custom-stack-defs.ts`, `services/pika/lib/stacks/custom-stack-defs.ts`), and shared tooling (`packages/tools/**`). Fallback list in `getDefaultProtectedAreas()` (`packages/pika-cli/src/commands/sync.ts`) mirrored. New `docs/concepts/pika-sync.md` documents the rationale per entry. [#147, #150]
+- **Docker build-cache optimization in `pika-chat-construct.ts`** — `cacheFrom: [{ type: 'gha' }]` is now conditionally passed to `DockerImageAsset` when `DOCKER_CACHE_FROM_GHA=true` (CI deploys via the deploy workflow), enabling near-instant CDK asset publishing on GHA cache hit. Local builds and non-GHA pipelines are unaffected — `buildx --cache-from type=gha` silently no-ops without `ACTIONS_CACHE_URL`. [#148]
+- **Generic robustness improvements** ported from ai-bot CM-491:
+  - **Cookie error path split** in `apps/pika-chat/src/lib/server/cookies.ts` — a corrupt `AUTH_USER` cookie now returns `no_auth_cookie` rather than wiping all other cookies via `version_mismatch`.
+  - **SSM `ParameterNotFound` graceful return** in `apps/pika-chat/src/lib/server/ssm.ts` — catches both typed `ParameterNotFound` and `error.name === 'ParameterNotFound'` and returns `undefined` for caller handling instead of re-throwing.
+  - **`chatAppState` null guards** in `apps/pika-chat/src/routes/(auth)/chat/[chatAppId]/+layout.svelte` — defensive guards on route transitions.
+  - **File-upload hardening** in `apps/pika-chat/src/routes/(auth)/api/site-admin/file/+server.ts` — MIME allowlist, filename sanitization (strip path separators, non-printable chars), and S3 key character-set validation on both POST and DELETE.
+  - **`isUserAllowedToUseSessionInsights` made async** in `apps/pika-chat/src/lib/server/utils.ts` to mirror `isUserAllowedAdminAccess`. All call sites updated. [#147]
+
+### Fixed
+
+- **Strands `debug_trace.py` gzip+base64 encoding** — `gzip_base64_encode` previously produced `base64(hex(gzip(s)))`; the JS client decoder at `apps/pika-chat/src/lib/client/util.ts` expects `base64(gzip(s))`. Encoded debug-trace payloads now round-trip cleanly and the LLM Instruction accordion in the trace UI decodes successfully. Added `test_debug_trace.py` regression suite. [#145]
+
+### Security
+
+- **Alpine base image bumped to 3.22.3** in `apps/pika-chat/Dockerfile` final stage (Snyk advisories on lower-version Alpine). [#151]
+- **`services/samples/weather-direct` SDK pins** — `@aws-sdk/client-lambda` pinned to `3.974.0` and `@aws-sdk/credential-provider-node` pinned to `3.972.1` to pull in patched `fast-xml-parser` (CVEs SNYK-JS-FASTXMLPARSER-15155603, -15307668, -15324289, -15677840, -15699647). Pinned versions only on the weather-direct sample to avoid forcing the workspace catalog. [#151]
+
+### Migration notes
+
+**Stricter admin gating**: If your deployment authenticates a mixed user population (e.g. some users via AzureAD, others via another provider) and you require admin access to be limited to a specific provider, implement `isUserAllowedAdminAccess(user)` in `apps/pika-chat/src/lib/custom/site-admin.ts` BEFORE running `pika sync` to v0.26.0. The default hook is a no-op that delegates to the existing `isUserSiteAdmin` check — adopting the seam before sync avoids any brief window where admin gating differs from your override.
+
+**Strands long-term memory is opt-in**: Existing Strands deployments without `agent_def.memory_feature` are unchanged. To enable, set `memory_feature.enabled = true` and provide a `memory_id` from AgentCore. Without `memory_id`, the handler logs a warning and runs without memory tools.
+
+---
+
 ## [0.25.2] - 2026-05-04
 
 ### Changed

--- a/apps/pika-docs/sidebar-config.ts
+++ b/apps/pika-docs/sidebar-config.ts
@@ -151,6 +151,7 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
                     { label: 'UI Theming', slug: 'guides/customization/theming' },
                     { label: 'Custom Logout Dialog', slug: 'guides/customization/custom-logout-dialog' },
                     { label: 'Extension Points', slug: 'guides/customization/extension-points' },
+                    { label: 'Demo-Mode Hooks', slug: 'guides/customization/demo-mode-hooks' },
                     { label: 'Client Lifecycle Hooks', slug: 'guides/customization/client-lifecycle-hooks' },
                     { label: 'Server Hooks', slug: 'guides/customization/server-hooks' },
                     { label: 'Build Custom Web Components', slug: 'guides/customization/build-web-components' },

--- a/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
@@ -7,6 +7,48 @@ Complete version history of the Pika Framework.
 
 ---
 
+## [0.26.0] - 2026-05-26
+
+### Added
+
+- **CM-491 framework seams — 11 AzureAD-friendly extension-point hooks** in `apps/pika-chat/src/lib/custom/`. Covers admin gating (`isUserAllowedAdminAccess` in `site-admin.ts`), legacy session loading (`loadLegacyChatsIfNeeded`, `getLegacyChatsSectionHeader`, `getLegacyChatsSectionTrigger`), session permissions (`isCurrentSessionReadOnly`), legacy-user-id validation (`validateLegacyUserIdIfNeeded`), entity extraction (`getSessionEntityValue`), session account-context transformation (`transformSessionAccountContext`), ChatUser role-merge bypass (`shouldBypassChatUserRoleMerge`), and auth-provider hooks (`onAuthProviderCallback`, `onBeforeAuth` in `server-hooks.ts`). All hooks default to no-op so existing deployments are unaffected. New `lib/custom/README.md` Extension Points section and pika-docs [Extension Points guide](/guides/customization/extension-points/). [#147]
+- **Demo-mode framework seams — 7 hooks + public CSS contract** in `apps/pika-chat/src/lib/custom/`: `getDemoBannerComponent` (banner slot), `getDemoModeMenuItem` (menu-item slot wired into 4 user dropdowns), `getUserRefreshIntervalMs` (polling cadence), `isInternalUser` (effective-user predicate), `resolveUserForHomeChatApps` (home-page chat-app filter), `shouldShowLogout` (Logout-item visibility in chat/admin/nav dropdowns), `shouldShowDetailedTrace` (detailed-trace UI gate). Public CSS contract via `--demo-banner-h` custom property reserves viewport space when a banner is mounted (5 selectors in `app.css` subtract banner height from `100svh`/`100vh` containers). Defaults preserve current behavior. New pika-docs [Demo-Mode Hooks guide](/guides/customization/demo-mode-hooks/). [#146]
+- **Strands-native long-term user memory** in the Python `converseStrands` Lambda. Agent-driven retrieval (`agent_core_memory.retrieve`) and explicit save (`record`) replace the legacy TypeScript Lambda's per-turn `CreateEventCommand` writes. Two-layer design preserves Bedrock prompt cache: `MEMORY_SYSTEM_PROMPT_ADDITION` describes capability in the shared system prompt; `NEW_SESSION_MEMORY_NUDGE` appends a lightweight retrieval trigger to the first user message of a new session only. Opt in via `agent_def.memory_feature.enabled = true` with a non-empty `memory_id` from AgentCore. New pika-docs [Strands Long-Term User Memory guide](/guides/advanced/strands-memory/). [#152]
+- **Services library account-context utilities** in `services/pika/src/lib/`:
+  - `batchGetUserCustomDataByUserIds()` — batched DDB BatchGet (size 100) with `p-retry` for admin enrichment paths
+  - `getAccountIdFieldNames()` / `getNormalizedAccountId()` / `hasSessionAccountContext()` / `getAccountBackfillAttributes()` — configurable account-ID resolution honoring `PIKA_ACCOUNT_ID_FIELD_NAMES` env var and `PikaConfig.accountIdFieldNames`
+  - `mergeSessionAttributes()` — DDB session-attribute merge helper used by admin search enrichment
+  - `CHAT_DEBUG_LOGS` env var gates noisy chat-API debug logs
+  - New `PikaConfig.accountIdFieldNames` option (defaults to `['accountId', 'account_id']`) wired into the `PIKA_ACCOUNT_ID_FIELD_NAMES` Lambda environment on all 3 converse-handler Lambda definitions in `PikaConstruct` [#149]
+
+### Changed
+
+- **Default `pika sync` `protectedAreas` expanded to v1.0.6** — 9 new default-protected paths cover account/entity integration extension points (`custom-shared-types.ts`, `custom-site-features.ts`, legacy session endpoint, custom-account-search-api, AzureAD callback route, `apps/pika-chat/tools/custom-*/**`), CDK stack-def files (`apps/pika-chat/infra/lib/stacks/custom-stack-defs.ts`, `services/pika/lib/stacks/custom-stack-defs.ts`), and shared tooling (`packages/tools/**`). Fallback list in `getDefaultProtectedAreas()` (`packages/pika-cli/src/commands/sync.ts`) mirrored. New `docs/concepts/pika-sync.md` documents the rationale per entry. [#147, #150]
+- **Docker build-cache optimization in `pika-chat-construct.ts`** — `cacheFrom: [{ type: 'gha' }]` is now conditionally passed to `DockerImageAsset` when `DOCKER_CACHE_FROM_GHA=true` (CI deploys via the deploy workflow), enabling near-instant CDK asset publishing on GHA cache hit. Local builds and non-GHA pipelines are unaffected — `buildx --cache-from type=gha` silently no-ops without `ACTIONS_CACHE_URL`. [#148]
+- **Generic robustness improvements** ported from ai-bot CM-491:
+  - **Cookie error path split** in `apps/pika-chat/src/lib/server/cookies.ts` — a corrupt `AUTH_USER` cookie now returns `no_auth_cookie` rather than wiping all other cookies via `version_mismatch`.
+  - **SSM `ParameterNotFound` graceful return** in `apps/pika-chat/src/lib/server/ssm.ts` — catches both typed `ParameterNotFound` and `error.name === 'ParameterNotFound'` and returns `undefined` for caller handling instead of re-throwing.
+  - **`chatAppState` null guards** in `apps/pika-chat/src/routes/(auth)/chat/[chatAppId]/+layout.svelte` — defensive guards on route transitions.
+  - **File-upload hardening** in `apps/pika-chat/src/routes/(auth)/api/site-admin/file/+server.ts` — MIME allowlist, filename sanitization (strip path separators, non-printable chars), and S3 key character-set validation on both POST and DELETE.
+  - **`isUserAllowedToUseSessionInsights` made async** in `apps/pika-chat/src/lib/server/utils.ts` to mirror `isUserAllowedAdminAccess`. All call sites updated. [#147]
+
+### Fixed
+
+- **Strands `debug_trace.py` gzip+base64 encoding** — `gzip_base64_encode` previously produced `base64(hex(gzip(s)))`; the JS client decoder at `apps/pika-chat/src/lib/client/util.ts` expects `base64(gzip(s))`. Encoded debug-trace payloads now round-trip cleanly and the LLM Instruction accordion in the trace UI decodes successfully. Added `test_debug_trace.py` regression suite. [#145]
+
+### Security
+
+- **Alpine base image bumped to 3.22.3** in `apps/pika-chat/Dockerfile` final stage (Snyk advisories on lower-version Alpine). [#151]
+- **`services/samples/weather-direct` SDK pins** — `@aws-sdk/client-lambda` pinned to `3.974.0` and `@aws-sdk/credential-provider-node` pinned to `3.972.1` to pull in patched `fast-xml-parser` (CVEs SNYK-JS-FASTXMLPARSER-15155603, -15307668, -15324289, -15677840, -15699647). Pinned versions only on the weather-direct sample to avoid forcing the workspace catalog. [#151]
+
+### Migration notes
+
+**Stricter admin gating**: If your deployment authenticates a mixed user population (e.g. some users via AzureAD, others via another provider) and you require admin access to be limited to a specific provider, implement `isUserAllowedAdminAccess(user)` in `apps/pika-chat/src/lib/custom/site-admin.ts` BEFORE running `pika sync` to v0.26.0. The default hook is a no-op that delegates to the existing `isUserSiteAdmin` check — adopting the seam before sync avoids any brief window where admin gating differs from your override.
+
+**Strands long-term memory is opt-in**: Existing Strands deployments without `agent_def.memory_feature` are unchanged. To enable, set `memory_feature.enabled = true` and provide a `memory_id` from AgentCore. Without `memory_id`, the handler logs a warning and runs without memory tools.
+
+---
+
 ## [0.25.2] - 2026-05-04
 
 ### Changed

--- a/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
@@ -7,12 +7,24 @@ Stay up to date with the latest Pika Framework releases, new features, and impor
 
 ## Current Version
 
+### What's New in 0.26.0
+
+- **CM-491 framework seams — 11 AzureAD-friendly extension-point hooks** in `apps/pika-chat/src/lib/custom/`. Admin gating (`isUserAllowedAdminAccess`), legacy session loading (`loadLegacyChatsIfNeeded`, header/trigger slots), session permissions (`isCurrentSessionReadOnly`), legacy-user-id validation, entity extraction, session account-context transformation, ChatUser role-merge bypass (`shouldBypassChatUserRoleMerge`), and auth-provider hooks (`onAuthProviderCallback`, `onBeforeAuth`). All hooks default to no-op — see the [Extension Points guide](/guides/customization/extension-points/).
+- **Demo-mode framework seams — 7 hooks + public CSS contract**. New hooks: banner slot, menu-item slot (wired into 4 dropdowns), polling-interval, effective-user predicate, home-page-user resolver, Logout visibility, detailed-trace gate. CSS contract via `--demo-banner-h` reserves viewport space when a banner is mounted. Defaults preserve current behavior — see the [Demo-Mode Hooks guide](/guides/customization/demo-mode-hooks/).
+- **Strands-native long-term user memory** in the Python `converseStrands` Lambda. Agent-driven retrieval (`agent_core_memory.retrieve`) and save (`record`) replace the legacy TS Lambda's per-turn `CreateEventCommand` writes. Two-layer design (system-prompt addition + first-turn nudge) preserves Bedrock prompt cache. Opt in via `agent_def.memory_feature.enabled = true` with a `memory_id` — see the [Strands Long-Term User Memory guide](/guides/advanced/strands-memory/).
+- **Services library account-context utilities** — `batchGetUserCustomDataByUserIds()`, configurable account-ID resolution via new `PikaConfig.accountIdFieldNames` / `PIKA_ACCOUNT_ID_FIELD_NAMES` env var, `mergeSessionAttributes()` helper, and `CHAT_DEBUG_LOGS` env gate for noisy chat-API debug logs. Defaults preserve current behavior.
+- **Sync `protectedAreas` expanded to v1.0.6** — 9 new default-protected paths cover account/entity integration extension points, CDK stack-def files, and shared tooling. Run `pika sync` after upgrading to pick up the new list automatically.
+- **Docker build-cache optimization in `pika-chat-construct.ts`** — `cacheFrom: [{ type: 'gha' }]` is conditionally passed to `DockerImageAsset` when `DOCKER_CACHE_FROM_GHA=true`, enabling near-instant CDK asset publishing on GHA cache hit. Local builds unaffected.
+- **5 generic robustness improvements ported from ai-bot CM-491** — cookie error/version-mismatch split (preserves non-auth cookies on corruption), SSM `ParameterNotFound` graceful return, `chatAppState` null guards on route transitions, file-upload hardening (MIME allowlist + filename sanitization + S3 key validation), and `isUserAllowedToUseSessionInsights` made async.
+- **Fixed gzip+base64 encoding in Strands `debug_trace.py`** — encoded payloads now round-trip through the JS client decoder; the LLM Instruction accordion in the trace UI decodes correctly.
+- **Security upgrades** — Alpine base image → 3.22.3, weather-direct sample pins `@aws-sdk/client-lambda` 3.974.0 and `@aws-sdk/credential-provider-node` 3.972.1 (patched `fast-xml-parser` for Snyk CVEs).
+
+**Latest Stable:** `0.26.0` (May 26, 2026)
+
 ### What's New in 0.25.2
 
 - **Strands converse Lambda `max_tokens` raised to 64000** - Both the main agent and collaborator `BedrockModel` configs now use Claude 4.5 Sonnet's actual max output (64K), up from a hardcoded 4096 leftover from older Claude defaults. Long-form responses (detailed explanations, code generation, multi-step plans) that previously truncated at ~3KB now stream through cleanly.
 - **Graceful `MaxTokensReachedException` handling** - When the model hits its max output limit, users now see "your request required more processing than I can handle in a single response. Try breaking it into smaller steps or simplifying your request." instead of a generic error message.
-
-**Latest Stable:** `0.25.2` (May 4, 2026)
 
 ### What's New in 0.25.1
 
@@ -624,6 +636,7 @@ When breaking changes are introduced:
 
 | Version | Date        | Type     | Summary                                       |
 | ------- | ----------- | -------- | --------------------------------------------- |
+| 0.26.0  | May 26 2026 | Feature  | CM-491 framework seams (11 AzureAD-friendly hooks), demo-mode seams (7 hooks + CSS contract), Strands long-term user memory, services library account-context utilities, sync protectedAreas v1.0.6 |
 | 0.25.2  | May 4 2026  | Patch    | Strands converse Lambda: raise max_tokens to model capacity (64K), add explicit MaxTokensReachedException handler |
 | 0.25.1  | May 4 2026  | Patch    | Back-port gaps from 0.25.0: hooks userType/roles propagation, jest integration-test isolation, flag-gated insights schedule, flag-conditional Strands SSM lookup |
 | 0.25.0  | Apr 23 2026 | Feature  | Optional Python (Strands) converse Lambda, Claude 4.5/4.6 default models, streaming heartbeats, post-processor rewrite |

--- a/releases.json
+++ b/releases.json
@@ -1,7 +1,25 @@
 {
-  "latestVersion": "0.25.2",
+  "latestVersion": "0.26.0",
   "currentDevelopment": "0.25.2",
   "releases": [
+    {
+      "version": "0.26.0",
+      "date": "2026-05-26",
+      "status": "released",
+      "breaking": false,
+      "summary": "Framework extension-point release: 11 AzureAD-friendly seams (CM-491), 7 demo-mode seams + CSS contract, Strands long-term user memory, services library account-context utilities, expanded sync protectedAreas (v1.0.6)",
+      "highlights": [
+        "CM-491 framework seams \u2014 11 AzureAD-friendly extension-point hooks in apps/pika-chat/src/lib/custom/ covering admin gating, legacy sessions, role-merge bypass, auth-provider callbacks, and session/entity transforms. All hooks default to no-op so existing deployments are unaffected.",
+        "Demo-mode framework seams \u2014 7 hooks (banner, menu-item, polling, effective-user, home-page-user, Logout visibility, detailed-trace gate) plus a public --demo-banner-h CSS contract that reserves viewport space for a mounted banner.",
+        "Strands-native long-term user memory in the Python converse Lambda \u2014 agent-driven retrieval and save via agent_core_memory tool; new-session nudge triggers reliable retrieval without busting Bedrock prompt cache. Opt in via agent_def.memory_feature.",
+        "Services library account-context utilities \u2014 batchGetUserCustomDataByUserIds, configurable PIKA_ACCOUNT_ID_FIELD_NAMES / PikaConfig.accountIdFieldNames resolution, mergeSessionAttributes helper, CHAT_DEBUG_LOGS env gate.",
+        "Sync protectedAreas expanded to v1.0.6 \u2014 9 new default-protected paths cover account/entity integration extension points, CDK stack-def files, and shared tooling.",
+        "Docker build-cache optimization in pika-chat-construct.ts \u2014 cacheFrom: [{ type: 'gha' }] conditional restructured for reliable CI cache hits without affecting local builds.",
+        "5 generic robustness improvements ported from ai-bot CM-491: cookie error/version-mismatch split, SSM ParameterNotFound graceful return, chatAppState null guards, file-upload hardening, async isUserAllowedToUseSessionInsights.",
+        "Fixed gzip+base64 encoding in Strands debug_trace so the LLM Instruction accordion in the trace UI decodes correctly.",
+        "Security: Alpine base image \u2192 3.22.3 and weather-direct SDK pins for patched fast-xml-parser (Snyk advisories)."
+      ]
+    },
     {
       "version": "0.25.2",
       "date": "2026-05-04",
@@ -9,7 +27,7 @@
       "breaking": false,
       "summary": "Strands converse Lambda: raise max_tokens to model capacity (64K) and add explicit MaxTokensReachedException handler",
       "highlights": [
-        "max_tokens raised from 4096 → 64000 in both main agent and collaborator BedrockModel configs — Claude 4.5 Sonnet's actual max output. Long responses no longer truncate at ~3KB.",
+        "max_tokens raised from 4096 \u2192 64000 in both main agent and collaborator BedrockModel configs \u2014 Claude 4.5 Sonnet's actual max output. Long responses no longer truncate at ~3KB.",
         "MaxTokensReachedException now caught explicitly with a user-facing 'try breaking into smaller steps' message, instead of falling through to the generic error handler"
       ]
     },
@@ -22,8 +40,8 @@
       "highlights": [
         "hooks.server.ts now propagates userType/roles from auth provider to DDB on initial login (closes the call-site gap that left PR #140's chat-ddb updateUser support unused)",
         "jest configs in pika-chat and services/pika now exclude integration tests by default; new test:integration script in pika-chat for opt-in runs",
-        "SessionInsightsSchedule EventBridge rule is now gated on sessionInsightsFeature.enabled — previously always-on regardless of the flag, incurring Bedrock costs when the feature was disabled",
-        "New SessionInsightsFeature.scheduleEnabled knob lets consumers deploy the insights infrastructure (runner Lambda + OpenSearch) while skipping the per-minute schedule — cost-control mode for manual/backfill-only invocation",
+        "SessionInsightsSchedule EventBridge rule is now gated on sessionInsightsFeature.enabled \u2014 previously always-on regardless of the flag, incurring Bedrock costs when the feature was disabled",
+        "New SessionInsightsFeature.scheduleEnabled knob lets consumers deploy the insights infrastructure (runner Lambda + OpenSearch) while skipping the per-minute schedule \u2014 cost-control mode for manual/backfill-only invocation",
         "PikaChatConstruct accepts new useStrandsConverse?: boolean prop driving the converse Lambda SSM key (converse_url vs converse_strands_url); reference bin/pika-chat.ts wires it from pikaConfig.siteFeatures.strandsConverse.enabled so a single flag drives both the construct and the URL lookup"
       ]
     },
@@ -34,13 +52,13 @@
       "breaking": false,
       "summary": "Optional Python (Strands) converse Lambda, new Claude 4.5/4.6 default models, streaming heartbeats, post-processor rewrite",
       "highlights": [
-        "New ConverseStrandsConstruct — opt-in Python converse Lambda with full feature parity, Strands Skills for directives (no Nova Lite call), Swarm for collaborators, queue-based streaming on Python 3.14 arm64",
+        "New ConverseStrandsConstruct \u2014 opt-in Python converse Lambda with full feature parity, Strands Skills for directives (no Nova Lite call), Swarm for collaborators, queue-based streaming on Python 3.14 arm64",
         "DEFAULT_ANTHROPIC_MODEL bumped to Claude 4.5 Sonnet; verification model to Claude 4.5 Haiku; added 4.5 Opus / 4.6 Sonnet / 4.6 Opus to registry; removed decommissioned Claude 3.x models",
-        "Lambda streaming <heartbeat/> every 15s + ALB idle timeout → 300s prevent connection drops on long agent responses; client-side stall indicator",
+        "Lambda streaming <heartbeat/> every 15s + ALB idle timeout \u2192 300s prevent connection drops on long agent responses; client-side stall indicator",
         "agent-post-processor rewrite handles both Converse envelope formats and unwraps AgentCommunication__sendMessage; Bedrock JSON sanitization workaround",
         "Session title generation hardened with try/catch and moved to Haiku",
         "Verification model ID gets us. prefix; inference-profile custom resource no longer churns on every deploy",
-        "Bumped aws-cdk-lib → ^2.249.0 / aws-cdk → ^2.1118.0 for Runtime.PYTHON_3_14"
+        "Bumped aws-cdk-lib \u2192 ^2.249.0 / aws-cdk \u2192 ^2.1118.0 for Runtime.PYTHON_3_14"
       ]
     },
     {
@@ -131,7 +149,7 @@
       "breaking": false,
       "summary": "Fix model ID validation to accept base model IDs without cross-region prefix",
       "highlights": [
-        "MODEL_ID_TO_MODEL now accepts base model IDs (e.g. anthropic.claude-sonnet-4-5-20250929-v1:0) in addition to cross-region prefixed IDs (us.anthropic.claude-…)",
+        "MODEL_ID_TO_MODEL now accepts base model IDs (e.g. anthropic.claude-sonnet-4-5-20250929-v1:0) in addition to cross-region prefixed IDs (us.anthropic.claude-\u2026)",
         "Fixes 400 error when updating foundation model on agents via chat-admin API with non-prefixed model IDs"
       ]
     },
@@ -691,7 +709,7 @@
       "summary": "Complete documentation site overhaul with Astro",
       "highlights": [
         "Brand new Astro-based documentation experience",
-        "Comprehensive documentation following Diátaxis framework",
+        "Comprehensive documentation following Di\u00e1taxis framework",
         "Reorganized content: Why Pika, Getting Started, Concepts, Capabilities, Guides, Reference, Platform",
         "Enhanced with detailed diagrams, code examples, and step-by-step instructions",
         "Improved navigation, search, and custom Markdoc components",


### PR DESCRIPTION
## Release: v0.26.0

Coordinator PR for the v0.26.0 release. Assembles release notes and bumps version metadata after the 8 Phase 1 dev tickets (ES-3073, ES-3082, ES-3126, ES-3128, ES-3129, ES-3130, ES-3131, ES-3133) landed on `main`.

## Changes

- **`CHANGELOG.md` and `apps/pika-docs/.../changelog.mdoc`** — Added v0.26.0 section organized by `Added` / `Changed` / `Fixed` / `Security` with a Migration Notes block covering admin-gating override timing and the opt-in Strands memory feature.
- **`releases.json`** — Prepended v0.26.0 entry (`status: released`, `breaking: false`); bumped `latestVersion` to `0.26.0`.
- **`apps/pika-docs/.../index.mdoc`** — Added "What's New in 0.26.0" callout, updated **Latest Stable** to `0.26.0 (May 26, 2026)`, added row to Version History table.
- **`apps/pika-docs/sidebar-config.ts`** — Added missing `Demo-Mode Hooks` entry under `Customization Guides`. This page was added in #146 but never registered in the sidebar, which has been failing `Deploy docs to GitHub Pages` on every main commit since.

## Highlights (TL;DR)

- **CM-491 framework seams** — 11 AzureAD-friendly extension-point hooks (#147)
- **Demo-mode framework seams** — 7 hooks + public CSS contract (#146)
- **Strands long-term user memory** in the Python converse Lambda (#152)
- **Services library account-context utilities** + new `accountIdFieldNames` config (#149)
- **Sync protectedAreas v1.0.6** — 9 new default-protected paths (#147 + #150)
- **Docker build-cache optimization** in `pika-chat-construct.ts` (#148)
- **5 generic robustness improvements** ported from ai-bot CM-491 (#147)
- **Fixed gzip+base64 encoding** in Strands `debug_trace.py` (#145)
- **Security** — Alpine 3.22.3 + weather-direct SDK pins (#151)

## Release tag

Local tag `v0.26.0` already created on this branch via `pnpm release:publish 0.26.0 --non-interactive`. **Push the tag to `origin` AFTER this PR merges to main** (`git push origin v0.26.0`).

## Test plan

- [ ] CHANGELOG / changelog.mdoc / index.mdoc reads cleanly and accurately reflects the 8 dev PRs
- [ ] `releases.json` validates as JSON; v0.26.0 entry present; `latestVersion: 0.26.0`
- [ ] Docs build succeeds (sidebar fix resolves the failing `Deploy docs to GitHub Pages` workflow)
- [ ] After merge: `git push origin v0.26.0` puts the tag on `main`
- [ ] Verify with `git branch --contains v0.26.0 | grep main`

## Jira

https://chb.atlassian.net/browse/ES-3135