### PR TITLE
fix(ES-3168): pika session-source UX bugs surfaced by ai-bot (fast-follow to ES-3127)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Open-source chat platform framework for building AI-powered conversational appli
 - **Search**: OpenSearch (session analytics)
 - **Auth**: `@auth/sveltekit`, JWT via `x-chat-auth`, Cognito
 - **Build**: pnpm 10, Turborepo, tsup, esbuild
-- **Test**: Jest 29, ts-jest
+- **Test**: Jest 29 + ts-jest (unit/logic); Vitest + `@testing-library/svelte` + jsdom for Svelte 5 component/DOM tests (added v0.27.0)
 - **CI/CD**: GitHub Actions (tests, npm publish, docs deploy). No application deployment — that's the downstream repo's job.
 
 ## Architecture
@@ -80,6 +80,7 @@ pnpm --filter @pika/service test  # Test specific package
 ```
 
 - Tests live in `test/` directories, suffix `*.test.ts`
+- **Two runners in `apps/pika-chat`**: Jest (`pnpm test`) for unit/logic tests, and Vitest + `@testing-library/svelte` + jsdom (`pnpm test:components`) for Svelte 5 component/DOM tests. `pnpm test` (jest) **excludes** `test/components/` (vitest's) and `test/integration/`, so a component test placed outside `test/components/` silently won't run under the runner you expect.
 - Tests depend on `build` in Turbo pipeline
 - Jest uses `ts-jest` preset with module mapping for `pika-shared`
 
@@ -106,8 +107,8 @@ pnpm release:plan-breaking      # Plan breaking change + migration guide
 ```
 
 - **Branch naming determines version bump**: `feat/` → minor, `fix/` → patch, `breaking/` → breaking change
-- **Files touched by release**: `releases.json`, `CHANGELOG.md`, `apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc`
-- **Breaking changes** also create migration guides in `apps/pika-docs/src/content/docs/platform/releases/migration-guides/`
+- **Files touched by every release**: `releases.json`, `CHANGELOG.md`, `apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc`, **and** `apps/pika-docs/src/content/docs/platform/releases/index.mdoc` (the "What's New" section, the "Latest Stable" line, and the Version History table at the bottom). The `release:notes` prompt lists all four — don't skip `index.mdoc`.
+- **Breaking changes** also create a migration guide in `apps/pika-docs/src/content/docs/platform/releases/migration-guides/` **and** register it in `apps/pika-docs/sidebar-config.ts` (Migration Guides list, newest first)
 - **Auto-release**: GitHub Actions (`auto-release.yml`) creates GitHub releases from `releases.json` on push to `main`
 
 ## Domain Context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the Pika Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.0] - 2026-06-02
+
+### Added
+
+- **`SessionSource.position` ordering seam** — a session source can render its sidebar group above or below the built-in "My Chats" group via a new additive `position?: 'before' | 'after'` field (default `'before'`, which preserves prior behavior). [#155]
+
+### Fixed
+
+- **Clicking a session in a custom session source now opens it** — `setCurrentSessionById` resolves sessions from registered session sources, not just the user's own chats; an unknown session id no longer silently starts a new chat. [#155]
+- **The sidebar chat list scrolls and its scrollbar is usable** — removed the sidebar "rail" toggle, which overlapped the scrollbar and intercepted click/drag (and made a long list appear unscrollable). The sidebar's header collapse icon now appears in every mode as the toggle, and `chat-titlebar` re-opens it when collapsed. [#155]
+- **`svelte-check` build no longer fails** on `#currentSessionIsReadOnly` ("'#user' is used before its initialization") — converted to the lazy `$derived.by` form. [#155]
+- **The mobile sidebar can be closed again** — the `appSidebarOpen` setter now passes the requested value to `setOpenMobile` instead of always `true`. [#155]
+
+### Notes
+
+Fast-follow to v0.27.0: ai-bot, the first consumer of the generic session-source feature, surfaced these five framework defects. `SessionSource` is defined in the sync-protected `apps/pika-chat/src/lib/custom/additional-session-sources.ts`, so the new `position` field does **not** propagate via `pika sync` — a consumer adds it to its own copy when adopting it (the framework reads `source.position`, defaulting to `'before'`). The reusable `pika-ux` `Sidebar.Rail` component is unchanged; only the chat sidebar stops rendering it.
+
+---
+
 ## [0.27.0] - 2026-05-27
 
 ### Changed

--- a/apps/pika-chat/src/lib/client/features/chat/chat-app.state.svelte.ts
+++ b/apps/pika-chat/src/lib/client/features/chat/chat-app.state.svelte.ts
@@ -105,6 +105,7 @@ import { ChatFileValidationError } from './lib/ChatFileValidationError';
 import type { ComponentRegistry } from './message-segments/component-registry';
 import { MessageSegmentProcessor } from './message-segments/segment-processor';
 import { ChatNavState } from './nav/chat-nav.state.svelte';
+import { resolveSessionById } from './session-resolver';
 import { WidgetRegistry } from './widgets/widget-registry';
 import { getContentHashString } from 'pika-shared/util/server-client-utils';
 
@@ -298,8 +299,12 @@ export class ChatAppState implements IChatAppState {
         return source?.isReadOnly?.(session) ?? false;
     });
 
-    #currentSessionIsReadOnly = $derived(
-        this.#currentSessionIsSharedBySomeoneElse ||
+    // Use $derived.by (lazy closure) rather than the eager $derived(expr) form: the expression
+    // references this.#user, which is declared later in the class, so the eager form trips
+    // TS "used before its initialization". This matches #currentSessionSourceIsReadOnly above.
+    #currentSessionIsReadOnly = $derived.by(
+        () =>
+            this.#currentSessionIsSharedBySomeoneElse ||
             isSessionReadOnly(this.#currentSession, this.#user) ||
             this.#currentSessionSourceIsReadOnly
     );
@@ -1730,7 +1735,9 @@ export class ChatAppState implements IChatAppState {
             return;
         }
         if (this.#appState.isMobile) {
-            this.#appSidebarState.setOpenMobile(this.#appState.isMobile);
+            // Pass the requested open state, not isMobile (which is always true here) — otherwise
+            // the mobile sidebar can be opened but never closed via this setter.
+            this.#appSidebarState.setOpenMobile(value);
         } else {
             this.#appSidebarState.setOpen(value);
         }
@@ -1874,7 +1881,16 @@ export class ChatAppState implements IChatAppState {
     }
 
     setCurrentSessionById(sessionId: string) {
-        this.#setSession(this.#chatSessions.find((session) => session.sessionId === sessionId));
+        // Resolve from regular chat sessions OR any registered source's loaded sessions. Source
+        // sessions are not in #chatSessions, so the previous #chatSessions-only lookup missed them
+        // and fell through to #setSession(undefined), which silently started a new interim chat.
+        // On a genuine miss (id in neither collection) leave the current session unchanged — only
+        // the explicit "new chat" entry points should create an interim session.
+        const sourceSessions = this.#sessionSources.flatMap((source) => this.sourceSessions(source.id));
+        const session = resolveSessionById(sessionId, this.#chatSessions, sourceSessions);
+        if (session) {
+            this.#setSession(session);
+        }
     }
 
     /**

--- a/apps/pika-chat/src/lib/client/features/chat/layout/chat-sidebar.svelte
+++ b/apps/pika-chat/src/lib/client/features/chat/layout/chat-sidebar.svelte
@@ -58,7 +58,14 @@
         <div class="flex flex-col gap-2 mt-1">
             <div class="flex items-center justify-between">
                 <div class="flex flex-1 items-center ml-1">
-                    {#if chat.mode === 'standalone' && chat.appSidebarOpen}
+                    <!--
+                        Sidebar collapse toggle. Shown in every mode whenever the sidebar is open
+                        (was previously standalone-only, with the sidebar "rail" providing the
+                        toggle in other modes). The rail was removed because it overlapped the
+                        scrollbar and intercepted drags; this header icon is its replacement, and
+                        chat-titlebar provides the re-open affordance when the sidebar is closed.
+                    -->
+                    {#if chat.appSidebarOpen}
                         <TooltipPlus tooltip={chat.appSidebarOpen ? 'Close Sidebar' : 'Open Sidebar'}>
                             <Button
                                 variant="ghost"
@@ -68,7 +75,7 @@
                                 ><PanelLeft style="width: 1.3rem; height: 1.7rem;" /></Button
                             >
                         </TooltipPlus>
-                        {#if appState.homePageSiteFeature && appState.homePageSiteFeature.linksToChatApps && appState.allChatApps.length > 0}
+                        {#if chat.mode === 'standalone' && appState.homePageSiteFeature && appState.homePageSiteFeature.linksToChatApps && appState.allChatApps.length > 0}
                             <Button onclick={() => goto('/')} variant="ghost" size="sm" class="flex-1 text-center"
                                 >{appState.homePageSiteFeature.navigationButtonText ?? 'AI Assistants'}</Button
                             >
@@ -102,5 +109,10 @@
     <!-- <Sidebar.Footer>
         <ChatNavUser />
     </Sidebar.Footer> -->
-    <Sidebar.Rail />
+    <!--
+        Sidebar.Rail removed (ES-3168 #3): the rail's hit area (-right-4, z-20) straddled the
+        sidebar's right edge, overlapping the scrollbar and intercepting click/drag. The header
+        PanelLeft toggle above (always visible when open) + the chat-titlebar open affordance
+        replace it. The reusable pika-ux Sidebar.Rail component is intentionally left intact.
+    -->
 </Sidebar.Root>

--- a/apps/pika-chat/src/lib/client/features/chat/layout/chat-sidebar.svelte
+++ b/apps/pika-chat/src/lib/client/features/chat/layout/chat-sidebar.svelte
@@ -110,7 +110,7 @@
         <ChatNavUser />
     </Sidebar.Footer> -->
     <!--
-        Sidebar.Rail removed (ES-3168 #3): the rail's hit area (-right-4, z-20) straddled the
+        Sidebar.Rail removed: the rail's hit area (-right-4, z-20) straddled the
         sidebar's right edge, overlapping the scrollbar and intercepting click/drag. The header
         PanelLeft toggle above (always visible when open) + the chat-titlebar open affordance
         replace it. The reusable pika-ux Sidebar.Rail component is intentionally left intact.

--- a/apps/pika-chat/src/lib/client/features/chat/nav/chat-nav.svelte
+++ b/apps/pika-chat/src/lib/client/features/chat/nav/chat-nav.svelte
@@ -5,6 +5,7 @@
     import * as Sidebar from 'pika-ux/shadcn/sidebar';
     import { getContext } from 'svelte';
     import { ChatAppState } from '../chat-app.state.svelte';
+    import type { SessionSource } from '$lib/custom/additional-session-sources';
 
     const chat = getContext<ChatAppState>('chatAppState');
 
@@ -141,7 +142,11 @@
     </Sidebar.Group>
 {/if}
 
-{#each chat.sessionSources as source (source.id)}
+<!--
+    A single session-source group. Rendered once per source, either before or after the
+    "My Chats" group depending on source.position (see the two {#each} blocks below).
+-->
+{#snippet sourceGroup(source: SessionSource)}
     {@const status = chat.sourceStatus(source.id)}
     {#if status === 'loading'}
         <Sidebar.Group>
@@ -193,6 +198,11 @@
             </div>
         </Sidebar.Group>
     {/if}
+{/snippet}
+
+<!-- Source groups rendered ABOVE "My Chats". position defaults to 'before' when omitted. -->
+{#each chat.sessionSources.filter((source) => source.position !== 'after') as source (source.id)}
+    {@render sourceGroup(source)}
 {/each}
 
 <!-- My Chats Section (existing, enhanced) -->
@@ -230,3 +240,8 @@
         {/each}
     </div>
 </Sidebar.Group>
+
+<!-- Source groups rendered BELOW "My Chats" (source.position === 'after'). -->
+{#each chat.sessionSources.filter((source) => source.position === 'after') as source (source.id)}
+    {@render sourceGroup(source)}
+{/each}

--- a/apps/pika-chat/src/lib/client/features/chat/session-resolver.ts
+++ b/apps/pika-chat/src/lib/client/features/chat/session-resolver.ts
@@ -1,0 +1,28 @@
+import type { ChatSession, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+
+/**
+ * Resolve a sessionId to a session from either the user's regular chat sessions or any
+ * registered session source's loaded sessions.
+ *
+ * Source sessions live in the per-source state map (see ChatAppState's #sourceState), not in
+ * #chatSessions — so a lookup that searches only #chatSessions misses them. That gap is the
+ * root cause of "clicking a source session does nothing": the id resolved to undefined and the
+ * caller fell through to creating a new interim chat.
+ *
+ * Returns undefined when the id is in neither collection. Callers should treat that as
+ * "no such session" and leave the current session unchanged — they must NOT pass the undefined
+ * through to a code path that starts a new interim chat.
+ *
+ * A regular chat session takes precedence over a source session with the same id (ids are
+ * expected to be unique across collections; the tie-break is defined for determinism).
+ */
+export function resolveSessionById(
+    sessionId: string,
+    chatSessions: ChatSession<RecordOrUndef>[],
+    sourceSessions: ChatSession<RecordOrUndef>[]
+): ChatSession<RecordOrUndef> | undefined {
+    return (
+        chatSessions.find((session) => session.sessionId === sessionId) ??
+        sourceSessions.find((session) => session.sessionId === sessionId)
+    );
+}

--- a/apps/pika-chat/src/lib/custom/additional-session-sources.ts
+++ b/apps/pika-chat/src/lib/custom/additional-session-sources.ts
@@ -21,6 +21,13 @@ export interface SessionSource {
     /** Header label rendered above this source's session list. */
     label?: string;
     /**
+     * Where this source's group renders relative to the built-in "My Chats" group in the sidebar.
+     * - `'before'` (default) renders the group above "My Chats" — preserves pre-v0.27.x behavior.
+     * - `'after'` renders the group below "My Chats".
+     * Omitting the field is treated as `'before'`.
+     */
+    position?: 'before' | 'after';
+    /**
      * Loads sessions for this source.
      *
      * Called client-side once per chat-app init, in parallel with other sources via Promise.allSettled.

--- a/apps/pika-chat/test/components/chat-nav.test.ts
+++ b/apps/pika-chat/test/components/chat-nav.test.ts
@@ -256,3 +256,62 @@ describe('chat-nav.svelte — sessionSources rendering', () => {
         expect(screen.queryByText('No sessions found.')).toBeNull();
     });
 });
+
+// ---------------------------------------------------------------------------
+// SessionSource.position — group ordering relative to "My Chats" (ES-3168 #1)
+// ---------------------------------------------------------------------------
+
+describe('chat-nav.svelte — SessionSource.position ordering', () => {
+    /** True when `b` follows `a` in document order. */
+    function follows(a: Element, b: Element): boolean {
+        return Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+    }
+
+    function loadedSourceChat(sources: SessionSource[], labels: Record<string, string>) {
+        return makeMockChat({
+            sessionSources: sources,
+            sourceStatus: vi.fn(() => 'loaded' as SourceStatus),
+            sourceSessions: vi.fn((id: string) => [makeSession(`${id}-s1`, `${id} session`)]),
+            sourceLabel: vi.fn((id: string) => labels[id]),
+        });
+    }
+
+    it('renders a source with no position BEFORE "My Chats" (default is before)', () => {
+        const src = makeSource('def-src', { label: 'Default Source' });
+        renderChatNav(loadedSourceChat([src], { 'def-src': 'Default Source' }));
+
+        const sourceLabel = screen.getByText('Default Source');
+        const myChats = screen.getByText('My Chats');
+        expect(follows(sourceLabel, myChats)).toBe(true); // My Chats comes after the source
+    });
+
+    it('renders a source with position "before" ABOVE "My Chats"', () => {
+        const src = makeSource('before-src', { label: 'Before Source', position: 'before' });
+        renderChatNav(loadedSourceChat([src], { 'before-src': 'Before Source' }));
+
+        const sourceLabel = screen.getByText('Before Source');
+        const myChats = screen.getByText('My Chats');
+        expect(follows(sourceLabel, myChats)).toBe(true);
+    });
+
+    it('renders a source with position "after" BELOW "My Chats"', () => {
+        const src = makeSource('after-src', { label: 'After Source', position: 'after' });
+        renderChatNav(loadedSourceChat([src], { 'after-src': 'After Source' }));
+
+        const myChats = screen.getByText('My Chats');
+        const sourceLabel = screen.getByText('After Source');
+        expect(follows(myChats, sourceLabel)).toBe(true); // the source comes after My Chats
+    });
+
+    it('places before-sources above and after-sources below "My Chats" simultaneously', () => {
+        const before = makeSource('b-src', { label: 'Top Source' }); // omitted → before
+        const after = makeSource('a-src', { label: 'Bottom Source', position: 'after' });
+        renderChatNav(loadedSourceChat([before, after], { 'b-src': 'Top Source', 'a-src': 'Bottom Source' }));
+
+        const top = screen.getByText('Top Source');
+        const myChats = screen.getByText('My Chats');
+        const bottom = screen.getByText('Bottom Source');
+        expect(follows(top, myChats)).toBe(true);
+        expect(follows(myChats, bottom)).toBe(true);
+    });
+});

--- a/apps/pika-chat/test/components/chat-nav.test.ts
+++ b/apps/pika-chat/test/components/chat-nav.test.ts
@@ -258,7 +258,7 @@ describe('chat-nav.svelte — sessionSources rendering', () => {
 });
 
 // ---------------------------------------------------------------------------
-// SessionSource.position — group ordering relative to "My Chats" (ES-3168 #1)
+// SessionSource.position — group ordering relative to "My Chats"
 // ---------------------------------------------------------------------------
 
 describe('chat-nav.svelte — SessionSource.position ordering', () => {

--- a/apps/pika-chat/test/session-resolver.test.ts
+++ b/apps/pika-chat/test/session-resolver.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for resolveSessionById — the lookup behind ChatAppState.setCurrentSessionById.
+ *
+ * Regression guard for the "clicking a source session does nothing" defect: source sessions
+ * live in the per-source state map, not in #chatSessions, so a #chatSessions-only lookup
+ * returned undefined and the caller silently started a new interim chat instead of selecting
+ * the clicked session.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { resolveSessionById } from '../src/lib/client/features/chat/session-resolver';
+import type { ChatSession, RecordOrUndef } from 'pika-shared/types/chatbot/chatbot-types';
+
+function makeSession(id: string, title = ''): ChatSession<RecordOrUndef> {
+    return {
+        sessionId: id,
+        userId: 'user-1',
+        agentId: 'agent-1',
+        chatAppId: 'app-1',
+        identityId: 'identity-1',
+        invocationMode: 'standard',
+        entityId: '',
+        createDate: '2024-01-01T00:00:00Z',
+        lastUpdate: '2024-01-01T00:00:00Z',
+        sessionAttributes: {},
+        title,
+    };
+}
+
+describe('resolveSessionById', () => {
+    const chatA = makeSession('chat-a', 'Chat A');
+    const chatB = makeSession('chat-b', 'Chat B');
+    const sourceX = makeSession('source-x', 'Legacy X');
+    const sourceY = makeSession('source-y', 'Legacy Y');
+
+    it('resolves a regular chat session by id', () => {
+        const result = resolveSessionById('chat-b', [chatA, chatB], [sourceX, sourceY]);
+        expect(result).toBe(chatB);
+    });
+
+    it('resolves a source session that is absent from chatSessions (the defect this guards)', () => {
+        const result = resolveSessionById('source-x', [chatA, chatB], [sourceX, sourceY]);
+        expect(result).toBe(sourceX);
+    });
+
+    it('returns undefined when the id is in neither collection (caller leaves current unchanged)', () => {
+        const result = resolveSessionById('does-not-exist', [chatA, chatB], [sourceX, sourceY]);
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when both collections are empty', () => {
+        expect(resolveSessionById('anything', [], [])).toBeUndefined();
+    });
+
+    it('prefers a regular chat session over a source session with the same id', () => {
+        const dupChat = makeSession('dup', 'From chats');
+        const dupSource = makeSession('dup', 'From source');
+        expect(resolveSessionById('dup', [dupChat], [dupSource])).toBe(dupChat);
+    });
+});

--- a/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
@@ -7,6 +7,25 @@ Complete version history of the Pika Framework.
 
 ---
 
+## [0.28.0] - 2026-06-02
+
+### Added
+
+- **`SessionSource.position` ordering seam** — a session source can render its sidebar group above or below the built-in "My Chats" group via a new additive `position?: 'before' | 'after'` field (default `'before'`, which preserves prior behavior). [#155]
+
+### Fixed
+
+- **Clicking a session in a custom session source now opens it** — `setCurrentSessionById` resolves sessions from registered session sources, not just the user's own chats; an unknown session id no longer silently starts a new chat. [#155]
+- **The sidebar chat list scrolls and its scrollbar is usable** — removed the sidebar "rail" toggle, which overlapped the scrollbar and intercepted click/drag (and made a long list appear unscrollable). The sidebar's header collapse icon now appears in every mode as the toggle, and `chat-titlebar` re-opens it when collapsed. [#155]
+- **`svelte-check` build no longer fails** on `#currentSessionIsReadOnly` ("'#user' is used before its initialization") — converted to the lazy `$derived.by` form. [#155]
+- **The mobile sidebar can be closed again** — the `appSidebarOpen` setter now passes the requested value to `setOpenMobile` instead of always `true`. [#155]
+
+### Notes
+
+Fast-follow to v0.27.0: ai-bot, the first consumer of the generic session-source feature, surfaced these five framework defects. `SessionSource` is defined in the sync-protected `apps/pika-chat/src/lib/custom/additional-session-sources.ts`, so the new `position` field does **not** propagate via `pika sync` — a consumer adds it to its own copy when adopting it (the framework reads `source.position`, defaulting to `'before'`).
+
+---
+
 ## [0.27.0] - 2026-05-27
 
 ### Changed

--- a/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
@@ -7,6 +7,18 @@ Stay up to date with the latest Pika Framework releases, new features, and impor
 
 ## Current Version
 
+### What's New in 0.28.0
+
+- **Session-source ordering (`SessionSource.position`)** — a session source can now render its sidebar group above or below the built-in "My Chats" group via a new additive `position?: 'before' | 'after'` field (default `'before'`). `SessionSource` lives in the sync-protected `apps/pika-chat/src/lib/custom/additional-session-sources.ts`, so add the field to your own copy when you adopt it (the framework reads `source.position`, defaulting to `'before'`).
+- **Fixed — clicking a session in a custom session source opens it.** `setCurrentSessionById` now resolves sessions from registered session sources, not just the user's own chats; an unknown id no longer silently starts a new chat.
+- **Fixed — the sidebar chat list scrolls and its scrollbar is usable.** Removed the sidebar "rail" that overlapped the scrollbar and intercepted click/drag. The sidebar's header collapse icon is now the toggle in every mode (the chat titlebar re-opens it when collapsed). The reusable `pika-ux` `Sidebar.Rail` component is unchanged.
+- **Fixed — `svelte-check` build blocker** on `#currentSessionIsReadOnly` ("'#user' is used before its initialization") — converted to the lazy `$derived.by` form.
+- **Fixed — the mobile sidebar can be closed again** — the toggle now passes the requested open state to `setOpenMobile`.
+
+**Why now**: fast-follow to v0.27.0 — ai-bot, the first consumer of the generic session-source feature, surfaced these five framework defects.
+
+**Latest Stable:** `0.28.0` (June 2, 2026)
+
 ### What's New in 0.27.0
 
 - **BREAKING — legacy-chats hooks redesigned as generic session-source seams** in `apps/pika-chat/src/lib/custom/`. The five ai-bot-named hooks shipped in v0.26.0 (`loadLegacyChatsIfNeeded`, `getLegacyChatsSectionHeader`, `getLegacyChatsSectionTrigger`, `isCurrentSessionReadOnly`, `validateLegacyUserIdIfNeeded`) are replaced by three generic seams: `getAdditionalSessionSources(user, chatAppId) → SessionSource[]`, `isSessionReadOnly(session, user)`, and `resolveRequestUserId(requestedUserId, sessionUserId, ctx)`. `LEGACY_ACTION_USER_ID_COOKIE` is removed. Client-side hook signatures now use `ChatUser<U>` (not `AuthenticatedUser<T, U>`) to keep server-only fields off the public hook surface. Sources load via `Promise.allSettled` so one failing source never breaks siblings — see the [Extension Points guide](/guides/customization/extension-points/) and the [v0.26.0 → v0.27.0 migration guide](/platform/releases/migration-guides/upgrading-to-0-27-0/).
@@ -14,8 +26,6 @@ Stay up to date with the latest Pika Framework releases, new features, and impor
 - **Svelte 5 component test infrastructure** — Vitest + `@testing-library/svelte` + jsdom added to `apps/pika-chat` alongside the existing Jest setup. New `pnpm test:components` script. Initial coverage: 7 tests for `chat-nav.svelte` across every session-source render state.
 
 **Why now**: no merged consumer is on v0.26.0 yet (ai-bot consumption was paused after the design smell was identified). This is the only window to redesign these seams without breaking a real consumer.
-
-**Latest Stable:** `0.27.0` (May 27, 2026)
 
 ### What's New in 0.26.0
 
@@ -644,6 +654,8 @@ When breaking changes are introduced:
 
 | Version | Date        | Type     | Summary                                       |
 | ------- | ----------- | -------- | --------------------------------------------- |
+| 0.28.0  | Jun 2 2026  | Feature  | Fast-follow to v0.27.0: SessionSource.position ordering seam; fixes for source-session click-through, sidebar scroll/rail overlap, a svelte-check build blocker, and the mobile sidebar toggle |
+| 0.27.0  | May 27 2026 | Breaking | Legacy-chats hooks redesigned as 3 generic session-source seams; `pika migrate v0.26.0-v0.27.0` CLI; Svelte 5 component test infrastructure |
 | 0.26.0  | May 26 2026 | Feature  | CM-491 framework seams (11 AzureAD-friendly hooks), demo-mode seams (7 hooks + CSS contract), Strands long-term user memory, services library account-context utilities, sync protectedAreas v1.0.6 |
 | 0.25.2  | May 4 2026  | Patch    | Strands converse Lambda: raise max_tokens to model capacity (64K), add explicit MaxTokensReachedException handler |
 | 0.25.1  | May 4 2026  | Patch    | Back-port gaps from 0.25.0: hooks userType/roles propagation, jest integration-test isolation, flag-gated insights schedule, flag-conditional Strands SSM lookup |

--- a/releases.json
+++ b/releases.json
@@ -1,11 +1,11 @@
 {
-  "latestVersion": "0.27.0",
+  "latestVersion": "0.28.0",
   "currentDevelopment": "0.28.0",
   "releases": [
     {
       "version": "0.28.0",
       "date": "2026-06-02",
-      "status": "unreleased",
+      "status": "released",
       "breaking": false,
       "summary": "Fast-follow to v0.27.0: an additive SessionSource.position ordering seam plus fixes for five session-source/sidebar defects surfaced by ai-bot, the first consumer of the generic session-source feature.",
       "highlights": [

--- a/releases.json
+++ b/releases.json
@@ -1,7 +1,21 @@
 {
   "latestVersion": "0.27.0",
-  "currentDevelopment": "0.27.0",
+  "currentDevelopment": "0.28.0",
   "releases": [
+    {
+      "version": "0.28.0",
+      "date": "2026-06-02",
+      "status": "unreleased",
+      "breaking": false,
+      "summary": "Fast-follow to v0.27.0: an additive SessionSource.position ordering seam plus fixes for five session-source/sidebar defects surfaced by ai-bot, the first consumer of the generic session-source feature.",
+      "highlights": [
+        "Added SessionSource.position ('before' | 'after', default 'before') — session-source groups can render above or below the built-in \"My Chats\" group. Additive; preserves prior behavior. SessionSource lives in the sync-protected lib/custom file, so consumers add the field to their own copy when adopting it.",
+        "Fixed: clicking a session in a custom session source now opens it (setCurrentSessionById resolves source sessions, not just the user's own chats; an unknown id no longer starts a new chat).",
+        "Fixed: the sidebar chat list scrolls and its scrollbar is usable — removed the sidebar rail that overlapped the scrollbar and intercepted click/drag. The header collapse icon is now the toggle in every mode.",
+        "Fixed: svelte-check build blocker on #currentSessionIsReadOnly ('#user used before its initialization') — converted to lazy $derived.by.",
+        "Fixed: the mobile sidebar can be closed again (appSidebarOpen setter passes the requested value to setOpenMobile instead of always true)."
+      ]
+    },
     {
       "version": "0.27.0",
       "date": "2026-05-27",


### PR DESCRIPTION
## Summary
Fast-follow to ES-3127. ai-bot is the first consumer of pika v0.27.0's generic **session sources** + sidebar feature, and surfaced five framework defects (all in pika-owned files, none fixable in a consumer's `lib/custom`). This PR fixes them in pika source and guards the behavioral ones with seam tests.

## Task Reference
- Jira: https://chb.atlassian.net/browse/ES-3168
- Parent: ES-3127 (relocation/gate, released)

## Changes
1. **`SessionSource.position` ordering seam** (#1) — new additive `position?: 'before' | 'after'` (default `'before'`, preserves current behavior). `chat-nav.svelte` renders source groups before/after the built-in "My Chats" group via a snippet + two filtered passes. *Was: legacy source always rendered above My Chats with no way to reorder.*
2. **Source-session click-through** (#4) — `setCurrentSessionById` now resolves sessions from registered sources (new pure `session-resolver.ts`), not just `#chatSessions`. An unknown id no longer silently starts a new interim chat. *Was: clicking a source session did nothing.*
3. **Sidebar scroll + rail** (#2/#3) — the sidebar rail (`-right-4`, `z-20`) straddled the right edge, overlapping the scrollbar and intercepting click/drag, which also made the list appear unscrollable. Removed `<Sidebar.Rail/>` from the chat sidebar; the header `PanelLeft` toggle now shows in all modes (was standalone-only) and `chat-titlebar` provides re-open. The reusable `pika-ux` `Sidebar.Rail` component is left intact. *#2 and #3 share this root cause.*
4. **`svelte-check` build blocker** (#5) — `#currentSessionIsReadOnly` uses `$derived.by` (lazy) so its forward reference to `#user` no longer trips "used before its initialization".
5. **Mobile toggle bug** (found while fixing #3) — `set appSidebarOpen` now passes the requested value to `setOpenMobile` (was `isMobile`, always `true`), so the mobile sidebar can be closed.

## Tests
- `test/components/chat-nav.test.ts` (vitest) — +4 tests: `position` default + DOM order before/after "My Chats". **13/13 green.**
- `test/session-resolver.test.ts` (jest) — 5 tests: source-session resolves; absent id → undefined (caller leaves current unchanged). **5/5 green.**
- `svelte-check`: **0 errors.**
- **Coverage gap (called out):** #2/#3 are layout-only and have no unit test; verified manually (long list scrolls + draggable scrollbar; toggle works in a no-auth harness against a mock consumer). The behavioral seams (#1/#4) carry the regression guards.

## Notes for reviewers
- **`SessionSource` lives in `lib/custom/additional-session-sources.ts`**, which is sync-protected. So this `position?` addition does **not** propagate to downstream consumers via `pika sync` — each consumer must add the field to its own copy when it wants to use it (the framework reads `source.position`, defaulting to `'before'`). ai-bot does this in its follow-up PR.
- Related: ES-3147 (pika ESM jest-test failures from the v0.27.0 sync) is separate and not addressed here.

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] Tests added (seam tests for #1/#4)
- [x] svelte-check clean