### PR TITLE
fix(converse-strands): surface current date on the user turn (ES-3198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Pika Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.1] - 2026-06-04
+
+### Fixed
+
+- **Agents resolve relative date ranges against the real current date** — the Strands converse handler now surfaces the current date on the user turn, so "year to date", "this month", "last 30 days", etc. resolve against today instead of a guessed year. `currentDate` was previously delivered only via `promptSessionAttributes`, which reach tool Lambdas but never the LLM, so date-relative queries could land in the wrong year. The date is appended to the user turn (not the system prompt) to preserve the Bedrock prompt cache and keep the `system_prompt == base_prompt` handler/collaborator contract; it reaches both the supervisor and its collaborators (via Swarm context). [#156]
+
 ## [0.28.0] - 2026-06-02
 
 ### Added

--- a/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
@@ -7,6 +7,12 @@ Complete version history of the Pika Framework.
 
 ---
 
+## [0.28.1] - 2026-06-04
+
+### Fixed
+
+- **Agents resolve relative date ranges against the real current date** — the Strands converse handler now surfaces the current date on the user turn, so "year to date", "this month", "last 30 days", etc. resolve against today instead of a guessed year. `currentDate` was previously delivered only via `promptSessionAttributes`, which reach tool Lambdas but never the LLM, so date-relative queries could land in the wrong year. The date is appended to the user turn (not the system prompt) to preserve the Bedrock prompt cache and keep the `system_prompt == base_prompt` handler/collaborator contract; it reaches both the supervisor and its collaborators (via Swarm context). [#156]
+
 ## [0.28.0] - 2026-06-02
 
 ### Added

--- a/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
@@ -7,6 +7,14 @@ Stay up to date with the latest Pika Framework releases, new features, and impor
 
 ## Current Version
 
+### What's New in 0.28.1
+
+- **Agents resolve relative dates against the real current date.** The Strands converse handler now puts the current date on the user turn, so "year to date", "this month", "last 30 days", etc. resolve against today instead of a guessed year. Previously `currentDate` was delivered only via `promptSessionAttributes` (which reach tool Lambdas, not the model), so date-relative queries could land in the wrong year. The date is appended to the user turn rather than the system prompt — preserving the Bedrock prompt cache and keeping the `system_prompt == base_prompt` handler/collaborator contract — and reaches both the supervisor and its collaborators (via Swarm context).
+
+**Why now**: ai-bot agents were resolving "year to date" to a prior full year in production.
+
+**Latest Stable:** `0.28.1` (June 4, 2026)
+
 ### What's New in 0.28.0
 
 - **Session-source ordering (`SessionSource.position`)** — a session source can now render its sidebar group above or below the built-in "My Chats" group via a new additive `position?: 'before' | 'after'` field (default `'before'`). `SessionSource` lives in the sync-protected `apps/pika-chat/src/lib/custom/additional-session-sources.ts`, so add the field to your own copy when you adopt it (the framework reads `source.position`, defaulting to `'before'`).
@@ -16,8 +24,6 @@ Stay up to date with the latest Pika Framework releases, new features, and impor
 - **Fixed — the mobile sidebar can be closed again** — the toggle now passes the requested open state to `setOpenMobile`.
 
 **Why now**: fast-follow to v0.27.0 — ai-bot, the first consumer of the generic session-source feature, surfaced these five framework defects.
-
-**Latest Stable:** `0.28.0` (June 2, 2026)
 
 ### What's New in 0.27.0
 
@@ -654,6 +660,7 @@ When breaking changes are introduced:
 
 | Version | Date        | Type     | Summary                                       |
 | ------- | ----------- | -------- | --------------------------------------------- |
+| 0.28.1  | Jun 4 2026  | Patch    | Strands converse: surface the current date on the user turn so agents resolve relative date ranges ("year to date", "last 30 days") against today instead of guessing the year |
 | 0.28.0  | Jun 2 2026  | Feature  | Fast-follow to v0.27.0: SessionSource.position ordering seam; fixes for source-session click-through, sidebar scroll/rail overlap, a svelte-check build blocker, and the mobile sidebar toggle |
 | 0.27.0  | May 27 2026 | Breaking | Legacy-chats hooks redesigned as 3 generic session-source seams; `pika migrate v0.26.0-v0.27.0` CLI; Svelte 5 component test infrastructure |
 | 0.26.0  | May 26 2026 | Feature  | CM-491 framework seams (11 AzureAD-friendly hooks), demo-mode seams (7 hooks + CSS contract), Strands long-term user memory, services library account-context utilities, sync protectedAreas v1.0.6 |

--- a/releases.json
+++ b/releases.json
@@ -1,11 +1,11 @@
 {
-  "latestVersion": "0.28.0",
+  "latestVersion": "0.28.1",
   "currentDevelopment": "0.28.1",
   "releases": [
     {
       "version": "0.28.1",
       "date": "2026-06-04",
-      "status": "unreleased",
+      "status": "released",
       "breaking": false,
       "summary": "Bug fix: the Strands converse Lambda now surfaces the current date on the user turn so agents resolve relative date ranges (\"year to date\", \"this month\", \"last 30 days\") against today instead of guessing the year.",
       "highlights": [

--- a/releases.json
+++ b/releases.json
@@ -1,7 +1,20 @@
 {
   "latestVersion": "0.28.0",
-  "currentDevelopment": "0.28.0",
+  "currentDevelopment": "0.28.1",
   "releases": [
+    {
+      "version": "0.28.1",
+      "date": "2026-06-04",
+      "status": "unreleased",
+      "breaking": false,
+      "summary": "Bug fix: the Strands converse Lambda now surfaces the current date on the user turn so agents resolve relative date ranges (\"year to date\", \"this month\", \"last 30 days\") against today instead of guessing the year.",
+      "highlights": [
+        "Fixed: agents resolve relative date ranges against the real current date. currentDate was delivered only via promptSessionAttributes, which reach tool Lambdas but never the LLM, so the model had no authoritative \"today\" and guessed the year (e.g. resolving \"year to date\" to a prior full year).",
+        "The date is appended to the user turn rather than the system prompt — preserves the Bedrock prompt cache and keeps the system_prompt == base_prompt handler/collaborator contract intact (same idiom as NEW_SESSION_MEMORY_NUDGE).",
+        "Reaches both the supervisor and its collaborators (via Swarm shared context).",
+        "Added regression contract test (tests/test_contract_current_date.py)."
+      ]
+    },
     {
       "version": "0.28.0",
       "date": "2026-06-02",

--- a/services/pika/src/lambda/converse-strands/handler.py
+++ b/services/pika/src/lambda/converse-strands/handler.py
@@ -1273,6 +1273,16 @@ def handler(event, context, chunk_queue: queue.Queue | None = None):
                 parts.append(file_info)
             agent_message = '\n\n'.join(parts)
 
+            # Date goes on the user turn, not the system prompt (cache) and not
+            # promptSessionAttributes (those reach only tool Lambdas, not the LLM), so the
+            # model resolves relative ranges against the real date instead of guessing.
+            agent_message = (
+                f"{agent_message}\n\nFor reference, the current date is {current_date}. "
+                "Use this as today's date when interpreting relative time periods such as "
+                '"year to date", "this month", or "last 30 days"; never assume the year '
+                "from training data."
+            )
+
             # Appended to the user turn rather than the system prompt to preserve system-prompt
             # cache hit rate — the system prompt is shared across users; per-session content
             # there would bust the Bedrock prompt cache for every user.

--- a/services/pika/src/lambda/converse-strands/tests/test_contract_current_date.py
+++ b/services/pika/src/lambda/converse-strands/tests/test_contract_current_date.py
@@ -1,0 +1,112 @@
+"""
+CONTRACT TESTS: Current date on the user turn.
+
+Observable behavior contract:
+  - currentDate is delivered to the LLM by appending it to the message (the user turn),
+    NOT the system prompt — promptSessionAttributes reach tool Lambdas, not the model,
+    and putting per-request content in the system prompt would bust the prompt cache.
+  - Without today's date in the prompt the model guesses the year for relative ranges
+    ("year to date", "last 30 days"). Regression guard for ES-3198.
+"""
+
+import contextlib
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+
+def _make_ctx():
+    ctx = MagicMock()
+    ctx.get_remaining_time_in_millis.return_value = 300_000
+    return ctx
+
+
+def _make_agent_def():
+    return {
+        'agent_id': 'agent-001', 'base_prompt': 'Be helpful.',
+        'foundation_model': 'us.anthropic.claude-sonnet-4-5-20250929-v1:0', 'tool_ids': [],
+    }
+
+
+def _standard_patches(agent_instance):
+    mock_ddb = MagicMock()
+    mock_table = MagicMock()
+    mock_ddb.Table.return_value = mock_table
+    mock_table.get_item.return_value = {'Item': {'user_id': 'user-001', 'session_id': 'sess-001'}}
+    return (
+        patch('handler.dynamodb', mock_ddb),
+        patch('handler.Agent', MagicMock(return_value=agent_instance)),
+        patch('handler.load_agent', return_value=_make_agent_def()),
+        patch('handler.load_tools', return_value=[]),
+        patch('handler.build_strands_tools', return_value=[]),
+        patch('handler.get_user', return_value={'user_id': 'user-001', 'custom_data': {}}),
+        patch('handler.get_messages', return_value=[]),
+        patch('handler.add_message'),
+        patch('handler.ensure_session'),
+    )
+
+
+def _run_and_capture_prompt():
+    import handler as h  # noqa: PLC0415
+
+    agent_instance = MagicMock(return_value='ok')
+    event = {
+        'body': json.dumps({
+            'agentId': 'agent-001', 'userId': 'user-001',
+            'sessionId': 'sess-date', 'message': 'Analyze my year to date orders',
+        })
+    }
+    with contextlib.ExitStack() as stack:
+        for p in _standard_patches(agent_instance):
+            stack.enter_context(p)
+        h.handler(event, _make_ctx())
+    agent_instance.assert_called_once()
+    return agent_instance.call_args.args[0] if agent_instance.call_args.args else ''
+
+
+class TestCurrentDateOnTurn:
+    def test_message_contains_current_date(self):
+        """The message sent to the LLM must include today's date (so relative ranges resolve)."""
+        prompt = _run_and_capture_prompt()
+        today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+        assert 'current date is' in prompt.lower(), (
+            f"Turn message must state the current date. Got: {prompt[-200:]!r}"
+        )
+        assert today in prompt, (
+            f"Turn message must contain today's date ({today}). Got: {prompt[-200:]!r}"
+        )
+
+    def test_date_not_injected_into_system_prompt(self):
+        """The date must NOT be in the system prompt (cache + contract): system_prompt == base_prompt."""
+        import handler as h  # noqa: PLC0415
+
+        captured = {}
+
+        def _capture_agent(**kwargs):
+            captured['system_prompt'] = kwargs.get('system_prompt', '')
+            inst = MagicMock(return_value='ok')
+            return inst
+
+        event = {
+            'body': json.dumps({
+                'agentId': 'agent-001', 'userId': 'user-001',
+                'sessionId': 'sess-date-sys', 'message': 'Analyze my year to date orders',
+            })
+        }
+        mock_ddb = MagicMock()
+        mock_ddb.Table.return_value.get_item.return_value = {'Item': {'user_id': 'user-001', 'session_id': 'sess-001'}}
+        with patch('handler.dynamodb', mock_ddb), \
+             patch('handler.Agent', _capture_agent), \
+             patch('handler.load_agent', return_value=_make_agent_def()), \
+             patch('handler.load_tools', return_value=[]), \
+             patch('handler.build_strands_tools', return_value=[]), \
+             patch('handler.get_user', return_value={'user_id': 'user-001', 'custom_data': {}}), \
+             patch('handler.get_messages', return_value=[]), \
+             patch('handler.add_message'), \
+             patch('handler.ensure_session'):
+            h.handler(event, _make_ctx())
+
+        assert captured['system_prompt'] == 'Be helpful.', (
+            f"Date must not be appended to system_prompt (breaks cache + base_prompt contract). "
+            f"Got: {captured['system_prompt']!r}"
+        )


### PR DESCRIPTION
## Summary

The Strands converse handler injects `currentDate` only into `sessionAttributes`/`promptSessionAttributes`, which are delivered to **tool Lambdas** but never to the **LLM**. With no authoritative "today" in its prompt, the model guesses the year when interpreting relative ranges ("year to date", "this month", "last 30 days").

Observed in a downstream consumer (rithum-bot/order-analyzer) against test stage:
- "Analyze my year to date orders" → model queried **full-year 2024** and stated *"Year-to-date is calculated as January 1, 2024 through December 31, 2024"* (today is 2026-06-04).

## Fix

Append the current date to the **user turn** (`agent_message`), not the system prompt. This mirrors the existing `NEW_SESSION_MEMORY_NUDGE` pattern and is deliberate:
- **System prompt is left untouched** → preserves Bedrock prompt-cache hit rate (the system prompt is shared/cached; `currentDate` changes every request) and keeps the existing handler/collaborator prompt contracts green.
- The turn message reaches the supervisor and, via Swarm context, its collaborators (which do the date math).

## Verification (test stage)

| Query | Before | After |
|---|---|---|
| "Analyze my year to date orders" (supervisor → collaborator) | `create_date 2024-01-01..2024-12-31` ❌ | `2026-01-01..2026-06-04` ✅ |
| "top selling items last 30 days" (collaborative) | (prod: Oct–Nov 2022) | `2026-05-05..2026-06-04` ✅ |
| direct `order-analyzer` invoke | `2024` full year ❌ | `2026-01-01..2026-06-04` ✅ |

- `./scripts/test.sh` → **414 passed** (contract suite unchanged since `system_prompt` is untouched).

## Task Reference
- Jira: https://chb.atlassian.net/browse/ES-3198

## Notes
- Consumer-side companion (ai-agents PR #49) de-poisons agent example prompts that hardcoded 2025 dates; that's necessary but insufficient on its own — this runtime change is what gives the model a real "today".
- Ripples to ai-bot on the next pika sync (currently pikaVersion 0.28.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)