### PR TITLE
chore(cli): bump pika-app to 1.7.0 (patch-overlay commands)

### DIFF
--- a/packages/pika-cli/package.json
+++ b/packages/pika-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pika-app",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "CLI tool for creating and managing Pika framework chat applications",
     "type": "module",
     "main": "dist/index.js",


### PR DESCRIPTION
Bumps the `pika-app` CLI to **1.7.0** so the npm release matches the patch-overlay commands shipped in framework v0.29.0 (#157): `pika capture-patch`, `pika sync --check-collisions`, and the sync reapply phase. Minor — additive, no breaking changes.

Merge this, then publish:
```
git checkout main && git pull
pnpm --filter pika-app build
cd packages/pika-cli && pnpm publish   # public registry; requires npm auth
```

## Task reference
- Jira: https://chb.atlassian.net/browse/ES-3083

🤖 Generated with [Claude Code](https://claude.com/claude-code)