### PR TITLE
fix(converse-strands): read invocationMode as the wire field for component invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Pika Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.1] - 2026-07-30
+
+### Fixed
+
+- **Component-mode requests now read the wire field the client actually sends** — the Strands converse Lambda's `determine_mode()` read only `mode`, but the client sends `invocationMode` (the field declared on `ConverseRequest`). The mismatch fell through to the `chatAppId`-present branch and silently resolved to `chat-app`: the tag definition's component system prompt never loaded, and widget responses came back as unstructured prose cast to the expected response type with no error raised. `invocationMode` now wins, with `mode` retained as a compatibility alias for existing callers. Added a contract test that derives the expected wire-field key from the client source on disk, so the two sides cannot silently drift apart again.
+
 ## [0.29.0] - 2026-06-04
 
 ### Added

--- a/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
@@ -7,6 +7,12 @@ Complete version history of the Pika Framework.
 
 ---
 
+## [0.29.1] - 2026-07-30
+
+### Fixed
+
+- **Component-mode requests now read the wire field the client actually sends** — the Strands converse Lambda's `determine_mode()` read only `mode`, but the client sends `invocationMode` (the field declared on `ConverseRequest`). The mismatch fell through to the `chatAppId`-present branch and silently resolved to `chat-app`: the tag definition's component system prompt never loaded, and widget responses came back as unstructured prose cast to the expected response type with no error raised. `invocationMode` now wins, with `mode` retained as a compatibility alias for existing callers. Added a contract test that derives the expected wire-field key from the client source on disk, so the two sides cannot silently drift apart again.
+
 ## [0.29.0] - 2026-06-04
 
 ### Added

--- a/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
@@ -7,6 +7,15 @@ Stay up to date with the latest Pika Framework releases, new features, and impor
 
 ## Current Version
 
+### What's New in 0.29.1
+
+- **Component-mode requests now read the wire field the client actually sends.** The Strands converse Lambda's `determine_mode()` read only `mode`, but the client sends `invocationMode` (the field declared on `ConverseRequest`). The mismatch fell through to the `chatAppId`-present branch and silently resolved to `chat-app`: the tag definition's component system prompt never loaded, and widget responses came back as unstructured prose cast to the expected response type with no error raised. `invocationMode` now wins, with `mode` retained as a compatibility alias for existing callers.
+- **New contract test guards the wire-field boundary.** It derives the expected key from the client source on disk (not hand-written) and asserts both the server and the shared `ConverseRequest` type agree with it, so the two sides cannot silently drift apart again.
+
+**Why now**: component-mode (embedded widget) invocations were silently falling back to full chat-app behavior — the failure was total and produced no error, just the wrong response shape.
+
+**Latest Stable:** `0.29.1` (July 30, 2026)
+
 ### What's New in 0.29.0
 
 - **Carry edits to seam-less framework files across `pika sync` as patches.** When you need to customize a framework-owned file that has no extension point, capture the edit as a `pika-patches/NNN-*.patch` instead of orphaning the whole file from upstream updates. See the [Patch Overlay guide](/guides/customization/patch-overlay/).
@@ -15,8 +24,6 @@ Stay up to date with the latest Pika Framework releases, new features, and impor
 - **`pika sync --check-collisions`** is a read-only CI gate that flags any framework file edited without a covering patch (it would be overwritten on the next sync). Protected files and sync PRs are exempt.
 
 **Why now**: downstream consumers need to customize framework files (e.g. `jest.config.js`) that have no seam, and whole-file protection silently freezes those files from all upstream updates. Patches keep the edit *and* the upstream stream.
-
-**Latest Stable:** `0.29.0` (June 4, 2026)
 
 ### What's New in 0.28.1
 
@@ -669,6 +676,7 @@ When breaking changes are introduced:
 
 | Version | Date        | Type     | Summary                                       |
 | ------- | ----------- | -------- | --------------------------------------------- |
+| 0.29.1  | Jul 30 2026 | Patch    | Strands converse: component-mode requests now read `invocationMode`, the wire field the client actually sends, instead of `mode`; new contract test derives the key from client source |
 | 0.29.0  | Jun 4 2026  | Feature  | `pika-patches/` overlay: carry edits to seam-less framework files across sync — `pika capture-patch`, `pika sync` reapply (`git apply --3way`), and a `--check-collisions` CI gate |
 | 0.28.1  | Jun 4 2026  | Patch    | Strands converse: surface the current date on the user turn so agents resolve relative date ranges ("year to date", "last 30 days") against today instead of guessing the year |
 | 0.28.0  | Jun 2 2026  | Feature  | Fast-follow to v0.27.0: SessionSource.position ordering seam; fixes for source-session click-through, sidebar scroll/rail overlap, a svelte-check build blocker, and the mobile sidebar toggle |

--- a/releases.json
+++ b/releases.json
@@ -1,7 +1,19 @@
 {
   "latestVersion": "0.29.0",
-  "currentDevelopment": "0.29.0",
+  "currentDevelopment": "0.29.1",
   "releases": [
+    {
+      "version": "0.29.1",
+      "date": "2026-07-30",
+      "status": "unreleased",
+      "breaking": false,
+      "summary": "Bug fix: the Strands converse Lambda now reads `invocationMode` as the wire field for component invocation, with `mode` retained as a compatibility alias.",
+      "highlights": [
+        "Fixed: component-mode requests resolve correctly again. determine_mode() read only `mode`, but the client sends `invocationMode` (declared on ConverseRequest). The mismatch fell through to the chatAppId-present branch and silently resolved to `chat-app`, so the tag definition's component system prompt never loaded and widget responses were unstructured prose cast to the expected type with no error raised.",
+        "`invocationMode` now wins; `mode` is retained as a compatibility alias for existing callers.",
+        "Added a contract test that derives the expected wire-field key from the client source on disk and asserts both the server and the shared ConverseRequest type agree with it, so the two sides cannot silently drift apart again."
+      ]
+    },
     {
       "version": "0.29.0",
       "date": "2026-06-04",

--- a/releases.json
+++ b/releases.json
@@ -1,11 +1,11 @@
 {
-  "latestVersion": "0.29.0",
+  "latestVersion": "0.29.1",
   "currentDevelopment": "0.29.1",
   "releases": [
     {
       "version": "0.29.1",
       "date": "2026-07-30",
-      "status": "unreleased",
+      "status": "released",
       "breaking": false,
       "summary": "Bug fix: the Strands converse Lambda now reads `invocationMode` as the wire field for component invocation, with `mode` retained as a compatibility alias.",
       "highlights": [

--- a/services/pika/src/lambda/converse-strands/chat_app_component.py
+++ b/services/pika/src/lambda/converse-strands/chat_app_component.py
@@ -1,7 +1,8 @@
 """
 chat-app-component invocation mode support.
 
-When a request arrives with mode='chat-app-component', the agent's base_prompt is
+When a request arrives in chat-app-component mode (the wire field is
+`invocationMode`; see invocation_mode.py), the agent's base_prompt is
 REPLACED by a tag definition's component_agent_instructions_md[name] content for
 that single request. This supports embedded-widget deployments where one agent
 is reused across N embedded surfaces, each with its own scoped system prompt.

--- a/services/pika/src/lambda/converse-strands/invocation_mode.py
+++ b/services/pika/src/lambda/converse-strands/invocation_mode.py
@@ -9,8 +9,23 @@ Mirrors the mode-determination block in the TS converse Lambda
   DIRECT_AGENT_INVOKE   programmatic invoke (no chatAppId; falls back to agentId)
   CHAT_APP_COMPONENT    embedded widget (validated separately in chat_app_component.py)
 
-Precedence: explicit body.mode wins; otherwise chatAppId→chat-app; otherwise
-direct-agent-invoke.
+Precedence: an explicit mode on the request wins; otherwise chatAppId→chat-app;
+otherwise direct-agent-invoke.
+
+## The wire field is `invocationMode` (field-name regression, fixed 2026-07-29)
+
+The client sends **`invocationMode`** — that is the field on `ConverseRequest`
+(packages/shared/src/types/chatbot/chatbot-types.ts) and the payload reaches this
+Lambda verbatim (`JSON.stringify(request)` in
+apps/pika-chat/src/lib/server/invoke-converse-fn-url.ts). The TS converse Lambda
+reads it correctly (services/pika/src/lambda/converse/index.ts). This module
+originally read only `mode`, so `invocationMode: 'chat-app-component'` fell through
+to the `chatAppId`-present branch and silently resolved to `chat-app`: component
+requests never got their tag-def system prompt, and the widget received unstructured
+prose instead of the JSON its instruction set was supposed to produce.
+
+`mode` is retained as an ALIAS because the local harness (local_invoke.py) and
+existing callers use it; `invocationMode` wins when both are present.
 """
 from typing import Any, Dict, List, Optional
 
@@ -20,16 +35,22 @@ CHAT_APP_COMPONENT = 'chat-app-component'
 
 SUPPORTED_MODES = (CHAT_APP, DIRECT_AGENT_INVOKE, CHAT_APP_COMPONENT)
 
+#: Request keys that may carry an explicit invocation mode, in precedence order.
+#: `invocationMode` is the real wire contract; `mode` is a retained alias.
+MODE_KEYS = ('invocationMode', 'mode')
+
 
 def determine_mode(body: Dict[str, Any]) -> str:
     """Return the active invocation mode for this request.
 
-    Explicit `body.mode` wins (even if invalid — validation is a separate step).
-    Otherwise infer from presence of chatAppId.
+    An explicit mode wins (even if invalid — validation is a separate step), read
+    from `invocationMode` first and then the `mode` alias. Otherwise infer from the
+    presence of chatAppId.
     """
-    explicit = body.get('mode')
-    if explicit:
-        return explicit
+    for key in MODE_KEYS:
+        explicit = body.get(key)
+        if explicit:
+            return explicit
     if body.get('chatAppId'):
         return CHAT_APP
     return DIRECT_AGENT_INVOKE

--- a/services/pika/src/lambda/converse-strands/tests/test_contract_invocation_mode.py
+++ b/services/pika/src/lambda/converse-strands/tests/test_contract_invocation_mode.py
@@ -11,9 +11,17 @@ Supported modes:
   - "chat-app-component"   : embedded widget (covered by test_contract_chat_app_component.py)
 
 Mode determination precedence:
-  1. If request.mode is explicitly set, use it (and validate per-mode requirements).
+  1. If an explicit mode is set, use it (and validate per-mode requirements).
   2. Else, if chatAppId is present → infer mode='chat-app'.
   3. Else → infer mode='direct-agent-invoke'.
+
+WIRE FIELD: the request key is `invocationMode` — that is what ConverseRequest
+declares and what the client actually sends. `mode` is a retained alias for the local
+harness. The bodies below deliberately use `invocationMode` so this suite exercises
+the real contract; these tests previously used only `mode`, which is how a
+field-name mismatch survived undetected (the tests authored their own input and so
+could only confirm the server agreed with the tests). Alias coverage and a
+client-source-derived guard live in test_contract_invocation_mode_wire_field.py.
 
 Per-mode validation:
   - chat-app:            requires chatAppId, agentId, userId, message, sessionId
@@ -48,7 +56,7 @@ class TestInvocationModeInference:
     def test_explicit_mode_wins_over_inference(self):
         from invocation_mode import determine_mode  # noqa: PLC0415
 
-        body = {'mode': 'direct-agent-invoke', 'chatAppId': 'rcs', 'agentId': 'a',
+        body = {'invocationMode': 'direct-agent-invoke', 'chatAppId': 'rcs', 'agentId': 'a',
                 'userId': 'u', 'message': 'm', 'sessionId': 's'}
         assert determine_mode(body) == 'direct-agent-invoke'
 
@@ -63,7 +71,7 @@ class TestInvocationModeValidation:
         from handler import handler as lambda_handler  # noqa: PLC0415
 
         event = {'body': json.dumps({
-            'mode': 'not-a-real-mode',
+            'invocationMode': 'not-a-real-mode',
             'agentId': 'a', 'userId': 'u', 'message': 'm', 'sessionId': 's',
         })}
         resp = lambda_handler(event, MagicMock())
@@ -73,7 +81,7 @@ class TestInvocationModeValidation:
         from handler import handler as lambda_handler  # noqa: PLC0415
 
         event = {'body': json.dumps({
-            'mode': 'chat-app',
+            'invocationMode': 'chat-app',
             'agentId': 'a', 'userId': 'u', 'message': 'm', 'sessionId': 's',
         })}
         resp = lambda_handler(event, MagicMock())
@@ -83,7 +91,7 @@ class TestInvocationModeValidation:
         """direct-agent-invoke must succeed (at validation) without chatAppId."""
         from invocation_mode import validate_for_mode  # noqa: PLC0415
 
-        body = {'mode': 'direct-agent-invoke', 'agentId': 'a', 'userId': 'u',
+        body = {'invocationMode': 'direct-agent-invoke', 'agentId': 'a', 'userId': 'u',
                 'message': 'm', 'sessionId': 's'}
         # validate_for_mode must not raise
         errors = validate_for_mode(body)
@@ -97,6 +105,6 @@ class TestInvocationModeValidation:
         """
         from invocation_mode import resolve_chat_app_id  # noqa: PLC0415
 
-        body = {'mode': 'direct-agent-invoke', 'agentId': 'order-analyzer-2',
+        body = {'invocationMode': 'direct-agent-invoke', 'agentId': 'order-analyzer-2',
                 'userId': 'u', 'message': 'm', 'sessionId': 's'}
         assert resolve_chat_app_id(body) == 'order-analyzer-2'

--- a/services/pika/src/lambda/converse-strands/tests/test_contract_invocation_mode_wire_field.py
+++ b/services/pika/src/lambda/converse-strands/tests/test_contract_invocation_mode_wire_field.py
@@ -1,0 +1,175 @@
+"""
+CONTRACT TESTS: the invocation-mode WIRE FIELD, asserted against the real client source.
+
+Why this file exists — the bug it exists to prevent:
+  The client sends `invocationMode`. This Lambda originally read only `mode`. So
+  `invocationMode: 'chat-app-component'` fell through to the chatAppId branch and
+  silently resolved to 'chat-app': component requests never received their tag-def
+  system prompt, and widgets got unstructured prose instead of the JSON their
+  instruction set was meant to produce. Nothing failed loudly.
+
+  The existing mode tests did not catch it because THEY AUTHORED THEIR OWN INPUT —
+  they hand-wrote `{'mode': ...}`, the very key the server happened to read. A test
+  that invents its payload can only ever confirm the server agrees with the test.
+
+  So these tests take the payload key from the CLIENT SOURCE ON DISK. If either side
+  is renamed, they fail. That is the point: this guards a cross-language boundary
+  (TypeScript client → Python Lambda) that no shared type can enforce, since the two
+  runtimes share no type system.
+
+Sources of truth read here:
+  - apps/pika-chat/src/lib/client/features/chat/chat-app.state.svelte.ts
+      the invokeAgentAsComponent() call site that builds the ConverseRequest
+  - packages/shared/src/types/chatbot/chatbot-types.ts
+      the ConverseRequest interface declaring the field
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from invocation_mode import (CHAT_APP, CHAT_APP_COMPONENT, DIRECT_AGENT_INVOKE,
+                             MODE_KEYS, determine_mode)
+
+# tests/ → converse-strands → lambda → src → pika → services → <repo root>
+REPO_ROOT = Path(__file__).resolve().parents[6]
+
+CLIENT_STATE = REPO_ROOT / 'apps/pika-chat/src/lib/client/features/chat/chat-app.state.svelte.ts'
+SHARED_TYPES = REPO_ROOT / 'packages/shared/src/types/chatbot/chatbot-types.ts'
+
+
+def _read(path: Path) -> str:
+    if not path.exists():
+        pytest.skip(
+            f'client source not present at {path} — this cross-boundary contract test '
+            f'only runs from a full repo checkout, not a packaged Lambda bundle'
+        )
+    return path.read_text(encoding='utf-8')
+
+
+def _invoke_agent_as_component_body() -> str:
+    """Return the source text of the client's invokeAgentAsComponent() method."""
+    src = _read(CLIENT_STATE)
+    start = src.find('async invokeAgentAsComponent')
+    assert start != -1, (
+        'could not find invokeAgentAsComponent in the client state source; if it was '
+        'renamed or moved, update this test — do NOT delete it'
+    )
+    # The ConverseRequest literal is built at the top of the method; a generous window
+    # covers it without depending on exact formatting.
+    return src[start:start + 2000]
+
+
+def client_mode_key() -> str:
+    """The request key the CLIENT actually uses to declare chat-app-component mode.
+
+    Extracted from the client source, never hand-written.
+    """
+    body = _invoke_agent_as_component_body()
+    match = re.search(r"(\w+)\s*:\s*'chat-app-component'", body)
+    assert match, (
+        "could not find a key assigned 'chat-app-component' in invokeAgentAsComponent; "
+        f'searched:\n{body[:600]}'
+    )
+    return match.group(1)
+
+
+class TestClientServerAgreeOnTheModeField:
+    """The server must honor the key the client actually sends."""
+
+    def test_client_mode_key_is_one_the_server_reads(self):
+        key = client_mode_key()
+        assert key in MODE_KEYS, (
+            f'the client declares invocation mode under {key!r}, but this Lambda only '
+            f'reads {MODE_KEYS!r}. That mismatch resolves component requests to '
+            f"'chat-app' SILENTLY."
+        )
+
+    def test_client_payload_resolves_to_component_mode(self):
+        """The decisive assertion: build the payload the way the CLIENT does.
+
+        chatAppId is included because the client sends it, and its presence is exactly
+        what made the original bug silent — it gave determine_mode a plausible wrong
+        answer instead of no answer.
+        """
+        body = {
+            client_mode_key(): 'chat-app-component',
+            'chatAppId': 'rcs',
+            'agentId': 'a-1',
+            'userId': 'u-1',
+            'message': 'answer the question',
+        }
+
+        assert determine_mode(body) == CHAT_APP_COMPONENT, (
+            'a payload shaped like the real client request did not resolve to '
+            'chat-app-component'
+        )
+
+    def test_shared_type_declares_the_same_field(self):
+        """ConverseRequest must declare the field the server reads."""
+        src = _read(SHARED_TYPES)
+        key = client_mode_key()
+        assert re.search(rf'\b{re.escape(key)}\??\s*:', src), (
+            f'{key!r} is sent by the client but is not declared on any type in '
+            f'chatbot-types.ts'
+        )
+
+
+class TestAliasAndFallbackBehavior:
+    """`mode` stays supported; precedence and inference are unchanged."""
+
+    def test_legacy_mode_alias_still_works(self):
+        """local_invoke.py and existing callers pass `mode` — must not break."""
+        assert determine_mode({'mode': 'chat-app-component', 'chatAppId': 'rcs'}) == CHAT_APP_COMPONENT
+
+    def test_invocation_mode_wins_over_alias(self):
+        body = {'invocationMode': CHAT_APP_COMPONENT, 'mode': DIRECT_AGENT_INVOKE, 'chatAppId': 'rcs'}
+        assert determine_mode(body) == CHAT_APP_COMPONENT, (
+            'invocationMode is the real wire contract and must take precedence'
+        )
+
+    def test_blank_explicit_mode_falls_through_to_inference(self):
+        assert determine_mode({'invocationMode': '', 'chatAppId': 'rcs'}) == CHAT_APP
+        assert determine_mode({'invocationMode': '', 'mode': '', 'agentId': 'a'}) == DIRECT_AGENT_INVOKE
+
+    def test_inference_unchanged_when_no_explicit_mode(self):
+        assert determine_mode({'chatAppId': 'rcs'}) == CHAT_APP
+        assert determine_mode({'agentId': 'a'}) == DIRECT_AGENT_INVOKE
+
+    def test_invalid_explicit_mode_is_returned_verbatim(self):
+        """Validation is a separate step; determine_mode must not sanitize."""
+        assert determine_mode({'invocationMode': 'not-a-real-mode'}) == 'not-a-real-mode'
+
+
+class TestComponentRequestReachesItsValidation:
+    """With the field read correctly, the component path actually engages."""
+
+    def test_real_client_payload_passes_component_validation(self):
+        from chat_app_component import (CHAT_APP_COMPONENT_MODE,
+                                        validate_chat_app_component_request)
+
+        body = {
+            client_mode_key(): 'chat-app-component',
+            'chatAppId': 'rcs',
+            'agentId': 'a-1',
+            'userId': 'u-1',
+            'message': 'answer the question',
+            'chatAppComponentConfig': {
+                'componentAgentInstructionName': 'answer-question',
+                'componentTagDefinition': {'scope': 'harmonizer', 'tag': 'question-card'},
+            },
+        }
+
+        assert determine_mode(body) == CHAT_APP_COMPONENT_MODE
+        assert validate_chat_app_component_request(body) is None
+
+    def test_component_payload_missing_config_is_rejected(self):
+        """The 400 path is only reachable once the mode resolves — pin that too."""
+        from chat_app_component import validate_chat_app_component_request
+
+        body = {client_mode_key(): 'chat-app-component', 'chatAppId': 'rcs',
+                'agentId': 'a-1', 'userId': 'u-1'}
+
+        assert determine_mode(body) == CHAT_APP_COMPONENT
+        assert validate_chat_app_component_request(body) is not None

--- a/services/pika/src/lambda/converse-strands/tests/test_contract_invocation_mode_wire_field.py
+++ b/services/pika/src/lambda/converse-strands/tests/test_contract_invocation_mode_wire_field.py
@@ -75,6 +75,36 @@ def client_mode_key() -> str:
     return match.group(1)
 
 
+def _converse_request_interface_block() -> str:
+    """Return the source text of the `ConverseRequest` interface body only.
+
+    `invocationMode` is declared on six interfaces in chatbot-types.ts (ChatSession,
+    ChatMessage, ConverseRequest, SessionSearchRequest, SessionAnalyticsRequest,
+    SessionAnalyticsCostByMode). Searching the whole file for the field would pass
+    vacuously if it were renamed on ConverseRequest alone and left on the others — the
+    contract this test exists to guard is specifically that ConverseRequest declares
+    what the client sends. Brace-counted so nested `{...}` in a future property
+    doesn't truncate the block early.
+    """
+    src = _read(SHARED_TYPES)
+    match = re.search(r'export interface ConverseRequest\b[^{]*\{', src)
+    assert match, (
+        'could not find "export interface ConverseRequest" in chatbot-types.ts; if it '
+        'was renamed or restructured, update this test — do NOT delete it'
+    )
+    depth = 0
+    i = match.end() - 1  # index of the interface's opening brace
+    while i < len(src):
+        if src[i] == '{':
+            depth += 1
+        elif src[i] == '}':
+            depth -= 1
+            if depth == 0:
+                return src[match.start():i + 1]
+        i += 1
+    raise AssertionError('unbalanced braces while scanning the ConverseRequest interface body')
+
+
 class TestClientServerAgreeOnTheModeField:
     """The server must honor the key the client actually sends."""
 
@@ -107,12 +137,14 @@ class TestClientServerAgreeOnTheModeField:
         )
 
     def test_shared_type_declares_the_same_field(self):
-        """ConverseRequest must declare the field the server reads."""
-        src = _read(SHARED_TYPES)
+        """ConverseRequest specifically — not just some interface in the file — must
+        declare the field the server reads.
+        """
+        interface_block = _converse_request_interface_block()
         key = client_mode_key()
-        assert re.search(rf'\b{re.escape(key)}\??\s*:', src), (
-            f'{key!r} is sent by the client but is not declared on any type in '
-            f'chatbot-types.ts'
+        assert re.search(rf'\b{re.escape(key)}\??\s*:', interface_block), (
+            f'{key!r} is sent by the client but is not declared on the ConverseRequest '
+            f'interface in chatbot-types.ts'
         )
 
 
@@ -132,6 +164,10 @@ class TestAliasAndFallbackBehavior:
     def test_blank_explicit_mode_falls_through_to_inference(self):
         assert determine_mode({'invocationMode': '', 'chatAppId': 'rcs'}) == CHAT_APP
         assert determine_mode({'invocationMode': '', 'mode': '', 'agentId': 'a'}) == DIRECT_AGENT_INVOKE
+
+    def test_blank_wire_key_yields_to_populated_alias(self):
+        """A blank invocationMode must not shadow a populated `mode` alias."""
+        assert determine_mode({'invocationMode': '', 'mode': CHAT_APP_COMPONENT, 'chatAppId': 'rcs'}) == CHAT_APP_COMPONENT
 
     def test_inference_unchanged_when_no_explicit_mode(self):
         assert determine_mode({'chatAppId': 'rcs'}) == CHAT_APP


### PR DESCRIPTION
## Summary
The converse-strands Lambda read the component invocation mode from the wrong field name: the client sends `invocationMode` (declared on `ConverseRequest`), but `determine_mode()` read only `mode`. The lookup silently returned nothing and fell through to the `chatAppId` branch, so component-mode requests resolved as `chat-app` — the tag definition's component system prompt (`componentAgentInstructionsMd`) never loaded, and widget responses were prose cast to the expected type with no error raised. The framework's own tests encoded the wrong field name, which is why this always passed.

This fix reads `invocationMode` as the wire field, keeps `mode` as a compatibility alias (`local_invoke.py` still sends it), and adds a contract test that derives the expected key from the client source on disk so the two sides cannot silently drift apart again. Release notes for v0.29.1 (patch) are included; the tag will be created from this branch via `release:publish` before merge, per the release process.

## Task Reference
- Jira: https://chb.atlassian.net/browse/RPL-5200
- Task: RPL-5200

## Changes Made
- `invocation_mode.py`: `MODE_KEYS = ('invocationMode', 'mode')` — `invocationMode` wins, `mode` honored as alias; `chatAppId` fallback and `direct-agent-invoke` default unchanged
- `tests/test_contract_invocation_mode.py`: 5 payloads updated to send the real wire field
- `tests/test_contract_invocation_mode_wire_field.py` (new): derives the wire key from `chat-app.state.svelte.ts` and asserts it against `determine_mode` and the `ConverseRequest` interface (scoped to that interface body so a rename there cannot pass vacuously); pins precedence, alias, blank-key fallthrough, and inference behavior
- `chat_app_component.py`: docstring correction
- Release notes for v0.29.1 across `CHANGELOG.md`, `releases.json`, `changelog.mdoc`, `index.mdoc` (status `unreleased` until `release:publish`)

## Testing
- `pnpm strands:test` (services/pika): **427 passed, 0 failed** — note this suite has no CI job, so this local run is the gate
- Mutation checks: reverting `MODE_KEYS` to `('mode',)` fails 9 tests; renaming `invocationMode` on `ConverseRequest` alone fails the scoped shared-type test
- `pnpm build`, `pnpm check-types`, `pnpm test` (turbo) pass for all non-sample packages; `pnpm release:validate` passes
- Pre-existing on main, unrelated to this change (reproduced on an unmodified checkout): `enterprise-site` build (Tailwind v4 PostCSS plugin), `@pika/weather` check-types, repo-wide `pnpm lint` (ESLint v9 flat-config migration pending), `pika-serverless` jest exiting 1 on zero test files

## Decision Log
- `mode` kept as an alias rather than removed: `local_invoke.py` and existing tests still send it; removal would be a breaking change out of scope for a patch fix
- Session persistence in component mode (`ensure_session`/`add_message` ungated by invocation mode) is intentionally NOT addressed here — it needs its own decision (see the Jira ticket)
- This upstreams a fix carried locally by a Pika consumer since it is a framework defect, not a local preference

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] Tests added/updated
- [x] Documentation updated
- [ ] AGENTS.md bootstrapped (if repo had none)
- [x] Knowledge captured (if applicable)
