### PR TITLE
chore(converse-strands): annotate callbacks with real Callable types + release v0.29.2 [RPL-5200]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Pika Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.2] - 2026-07-30
+
+### Fixed
+
+- **The Strands converse Lambda's callback annotations are real types again** — `trace_callback` was annotated `callable | None` in `agent_loader.py`. `callable` is the builtin *function*, not a type, and `callable | None` raises `TypeError` the moment it is evaluated. It stayed inert only because the Lambda pins Python 3.14, where annotations are evaluated lazily; on Python 3.13 or earlier the annotation is evaluated at import and breaks the entire module. Even on 3.14, anything that resolves annotations at runtime — `typing.get_type_hints()`, `annotationlib.get_annotations()`, and libraries built on them such as pydantic or dataclasses — raised `TypeError` against this module. `handler.py`'s `_make_callback` carried the same defect as a `-> callable` return annotation. Both sites now use `Callable[..., None]` from `collections.abc`; these were the only two bare-`callable` annotations in the framework. Annotations only — no signature, behavior, or dependency change. If you carried this fix downstream as a `pika-patches/` entry, you can drop the patch after syncing. [#161]
+
 ## [0.29.1] - 2026-07-30
 
 ### Fixed

--- a/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/changelog.mdoc
@@ -7,6 +7,12 @@ Complete version history of the Pika Framework.
 
 ---
 
+## [0.29.2] - 2026-07-30
+
+### Fixed
+
+- **The Strands converse Lambda's callback annotations are real types again** — `trace_callback` was annotated `callable | None` in `agent_loader.py`. `callable` is the builtin *function*, not a type, and `callable | None` raises `TypeError` the moment it is evaluated. It stayed inert only because the Lambda pins Python 3.14, where annotations are evaluated lazily; on Python 3.13 or earlier the annotation is evaluated at import and breaks the entire module. Even on 3.14, anything that resolves annotations at runtime — `typing.get_type_hints()`, `annotationlib.get_annotations()`, and libraries built on them such as pydantic or dataclasses — raised `TypeError` against this module. `handler.py`'s `_make_callback` carried the same defect as a `-> callable` return annotation. Both sites now use `Callable[..., None]` from `collections.abc`; these were the only two bare-`callable` annotations in the framework. Annotations only — no signature, behavior, or dependency change. If you carried this fix downstream as a `pika-patches/` entry, you can drop the patch after syncing. [#161]
+
 ## [0.29.1] - 2026-07-30
 
 ### Fixed

--- a/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
+++ b/apps/pika-docs/src/content/docs/platform/releases/index.mdoc
@@ -7,14 +7,22 @@ Stay up to date with the latest Pika Framework releases, new features, and impor
 
 ## Current Version
 
+### What's New in 0.29.2
+
+- **The Strands converse Lambda's callback annotations are real types again.** `trace_callback` was annotated `callable | None` in `agent_loader.py` — but `callable` is the builtin *function*, not a type, and `callable | None` raises `TypeError` the moment it is evaluated. `handler.py`'s `_make_callback` carried the same defect as a `-> callable` return annotation. Both now use `Callable[..., None]` from `collections.abc`.
+- **Why it was invisible.** The annotation stayed inert only because the Lambda pins Python 3.14, where annotations are evaluated lazily. On Python 3.13 or earlier the same annotation is evaluated at import and breaks the entire module — so the code was one runtime pin away from a hard `ImportError`.
+- **What it actually broke on 3.14.** Anything that resolves annotations at runtime — `typing.get_type_hints()`, `annotationlib.get_annotations()`, and libraries built on them such as pydantic or dataclasses — raised `TypeError` against this module. It now resolves cleanly, which is what makes a type-checker pass over this Lambda achievable at all.
+
+**Upgrade impact**: none. Annotations only — no signature, behavior, or dependency change (`collections.abc` is stdlib). If you carried this fix downstream as a `pika-patches/` entry, you can drop the patch after syncing.
+
+**Latest Stable:** `0.29.2` (July 30, 2026)
+
 ### What's New in 0.29.1
 
 - **Component-mode requests now read the wire field the client actually sends.** The Strands converse Lambda's `determine_mode()` read only `mode`, but the client sends `invocationMode` (the field declared on `ConverseRequest`). The mismatch fell through to the `chatAppId`-present branch and silently resolved to `chat-app`: the tag definition's component system prompt never loaded, and widget responses came back as unstructured prose cast to the expected response type with no error raised. `invocationMode` now wins, with `mode` retained as a compatibility alias for existing callers.
 - **New contract test guards the wire-field boundary.** It derives the expected key from the client source on disk (not hand-written) and asserts both the server and the shared `ConverseRequest` type agree with it, so the two sides cannot silently drift apart again.
 
 **Why now**: component-mode (embedded widget) invocations were silently falling back to full chat-app behavior — the failure was total and produced no error, just the wrong response shape.
-
-**Latest Stable:** `0.29.1` (July 30, 2026)
 
 ### What's New in 0.29.0
 
@@ -676,6 +684,7 @@ When breaking changes are introduced:
 
 | Version | Date        | Type     | Summary                                       |
 | ------- | ----------- | -------- | --------------------------------------------- |
+| 0.29.2  | Jul 30 2026 | Patch    | Strands converse: `trace_callback` and `_make_callback` annotated with real `Callable[..., None]` types instead of the `callable` builtin — the old annotation raised `TypeError` under any runtime annotation introspection, and breaks the module outright on Python 3.13 or earlier |
 | 0.29.1  | Jul 30 2026 | Patch    | Strands converse: component-mode requests now read `invocationMode`, the wire field the client actually sends, instead of `mode`; new contract test derives the key from client source |
 | 0.29.0  | Jun 4 2026  | Feature  | `pika-patches/` overlay: carry edits to seam-less framework files across sync — `pika capture-patch`, `pika sync` reapply (`git apply --3way`), and a `--check-collisions` CI gate |
 | 0.28.1  | Jun 4 2026  | Patch    | Strands converse: surface the current date on the user turn so agents resolve relative date ranges ("year to date", "last 30 days") against today instead of guessing the year |

--- a/releases.json
+++ b/releases.json
@@ -1,7 +1,20 @@
 {
-  "latestVersion": "0.29.1",
-  "currentDevelopment": "0.29.1",
+  "latestVersion": "0.29.2",
+  "currentDevelopment": "0.29.2",
   "releases": [
+    {
+      "version": "0.29.2",
+      "date": "2026-07-30",
+      "status": "released",
+      "breaking": false,
+      "summary": "Maintenance: the Strands converse Lambda's callback type annotations are now real types, so the module survives runtime annotation introspection and a type-checker pass.",
+      "highlights": [
+        "Fixed: `trace_callback` was annotated `callable | None` in `agent_loader.py`. `callable` is the builtin function, not a type, and `callable | None` raises TypeError the moment it is evaluated. The annotation stayed inert only because the Lambda pins Python 3.14, where annotations are evaluated lazily — on Python 3.13 or earlier it is evaluated at import and breaks the whole module.",
+        "Fixed: even on Python 3.14, anything that resolves annotations at runtime — `typing.get_type_hints()`, `annotationlib.get_annotations()`, and libraries built on them such as pydantic or dataclasses — raised TypeError against this module. It now resolves cleanly.",
+        "Fixed: `handler.py`'s `_make_callback` carried the same defect as a `-> callable` return annotation. Both sites now use `Callable[..., None]` from `collections.abc`; these were the only two bare-`callable` annotations in the framework.",
+        "Annotations only — no signature, behavior, or dependency change (`collections.abc` is stdlib). If you carried this fix downstream as a `pika-patches/` entry, you can drop the patch after syncing."
+      ]
+    },
     {
       "version": "0.29.1",
       "date": "2026-07-30",

--- a/services/pika/src/lambda/converse-strands/agent_loader.py
+++ b/services/pika/src/lambda/converse-strands/agent_loader.py
@@ -7,6 +7,8 @@ ActionGroupInvocationInput payload format.
 import os
 import json
 import logging
+from collections.abc import Callable
+
 import boto3
 
 # Constants for the Bedrock ActionGroupInvocationInput payload
@@ -110,7 +112,7 @@ def build_strands_tools(
     input_text: str = '',
     session_attributes: dict | None = None,
     prompt_session_attributes: dict | None = None,
-    trace_callback: callable | None = None,
+    trace_callback: Callable[..., None] | None = None,
     *,
     tool_definitions: list[dict] | None = None,
 ) -> list:
@@ -248,7 +250,7 @@ def _make_tool(tool_id: str, lambda_arn: str, func_name: str,
                func_desc: str, params, session_id: str,
                input_text: str, session_attributes: dict | None = None,
                prompt_session_attributes: dict | None = None,
-               trace_callback: callable | None = None) -> PythonAgentTool:
+               trace_callback: Callable[..., None] | None = None) -> PythonAgentTool:
     """Create a PythonAgentTool that invokes a tool Lambda.
 
     Uses late-binding-safe closures — all variables captured at definition time.

--- a/services/pika/src/lambda/converse-strands/handler.py
+++ b/services/pika/src/lambda/converse-strands/handler.py
@@ -8,6 +8,7 @@ import time
 import uuid
 import logging
 import threading
+from collections.abc import Callable
 from datetime import datetime, timezone
 import boto3
 import jwt as pyjwt
@@ -215,7 +216,7 @@ class _StreamWriter:
 # Strands callback handler
 # ---------------------------------------------------------------------------
 
-def _make_callback(stream: _StreamWriter) -> callable:
+def _make_callback(stream: _StreamWriter) -> Callable[..., None]:
     """Return a Strands callback_handler that writes chunks and traces to *stream*.
 
     The callback is called synchronously during agent execution, so it can write


### PR DESCRIPTION
### What

`callable` was used as a *type* annotation in two places in the Strands converse Lambda. `callable` is
the builtin **function**, not a type — so the annotation documents a value where a type belongs.

- `services/pika/src/lambda/converse-strands/agent_loader.py` — `trace_callback: callable | None` on
  `build_strands_tools()` and `_make_tool()`
- `services/pika/src/lambda/converse-strands/handler.py` — `_make_callback(...) -> callable`

Both now use `Callable[..., None]` from `collections.abc`. A repo-wide scan confirms these were the
**only** two bare-`callable` annotations in pika.

### Why it matters — this is not a style preference

`callable | None` is an **invalid expression**, not merely a loose type:

```
TypeError: unsupported operand type(s) for |: 'builtin_function_or_method' and 'NoneType'
```

There is no `from __future__ import annotations` in the module, so:

- **On Python ≤ 3.13** annotations are evaluated eagerly at `def` time — the annotation raises and
  **`agent_loader` fails to import at all**. The code survives only because
  `converse-strands-construct.ts` pins `Runtime.PYTHON_3_14`, where PEP 649/749 defers evaluation.
- **On Python 3.14** it is still not inert: anything that resolves annotations at runtime raises
  against this module. Measured, before → after:

  | | `typing.get_type_hints()` | `annotationlib.get_annotations()` |
  |---|---|---|
  | before | `TypeError` | `TypeError` |
  | after | resolves cleanly | resolves cleanly |

  That covers pydantic, dataclasses, FastAPI, type checkers, and any introspection-based tooling —
  and it is what makes a clean type-checker pass over this Lambda achievable at all.

`handler.py`'s `-> callable` is the **milder** half: bare `callable` without `| None` is a valid
expression, so it resolves to `<built-in function callable>` — statically meaningless but
runtime-inert. It's fixed here because leaving it means the type-checker goal above still isn't met.

### Why `Callable[..., None]` and not something tighter

The actual callee is `_StreamWriter.write_tool_result_trace(tool_name, result_text, invocation_input=None) -> None`.
It is invoked both positionally (`agent_loader.py:354`, `:368`, `:386`) and with the
`invocation_input` kwarg (`:337`), so a fixed parameter list would be wrong. The return value is
never consumed anywhere in either module.

### Risk

None at runtime. Annotations only — no signature change, no behavior change, no new dependency
(`collections.abc` is stdlib).

### Verification

- `427 passed` — full `converse-strands` pytest suite (Python 3.14.6).
- `typing.get_type_hints()` resolves cleanly on all three fixed functions (`build_strands_tools`,
  `_make_tool`, `_make_callback`) — it raised `TypeError` on two of them before.
- `pnpm release:validate` — all checks pass.

### Release

Includes the **v0.29.2** patch release (branch is `chore/*` → patch bump from 0.29.1):
`releases.json` (status `released`, 2026-07-30), `CHANGELOG.md`, `changelog.mdoc`, and `index.mdoc`
(What's New, Latest Stable, Version History row). Tag `v0.29.2` is created locally and **not yet
pushed**.

### Provenance

Carried downstream in `rithum/ai-bot` as `pika-patches/098-agent-loader.patch` — that patch is
byte-for-byte identical to the `agent_loader.py` half of this change, with nothing ai-bot-specific in
it. Upstreaming lets ai-bot delete the patch. The `handler.py` half was never patched downstream.

### Task Reference

- Jira: https://chb.atlassian.net/browse/RPL-5200
- Task: RPL-5200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
