### PR TITLE
fix(tools): make release --dry-run actually skip releases.json writes

### DIFF
--- a/packages/tools/src/release.ts
+++ b/packages/tools/src/release.ts
@@ -467,7 +467,7 @@ async function ensureUnreleasedVersion(): Promise<string> {
  * Uses existing unreleased version if present (matching interactive behavior),
  * warns if bump type doesn't match.
  */
-function ensureUnreleasedVersionNonInteractive(bumpType: 'major' | 'minor' | 'patch'): string {
+function ensureUnreleasedVersionNonInteractive(bumpType: 'major' | 'minor' | 'patch', dryRun: boolean = false): string {
     const releases = loadReleasesJson();
     const mainReleases = loadReleasesJsonFromMain();
 
@@ -500,8 +500,13 @@ function ensureUnreleasedVersionNonInteractive(bumpType: 'major' | 'minor' | 'pa
         highlights: []
     });
     releases.currentDevelopment = newVersion;
-    saveReleasesJson(releases);
-    log(chalk.green(`✓ Created unreleased version ${newVersion} in releases.json`));
+
+    if (dryRun) {
+        log(chalk.cyan(`Dry run: would create unreleased version ${newVersion} in releases.json`));
+    } else {
+        saveReleasesJson(releases);
+        log(chalk.green(`✓ Created unreleased version ${newVersion} in releases.json`));
+    }
 
     return newVersion;
 }
@@ -1500,7 +1505,7 @@ async function unifiedRelease(options: { nonInteractive?: boolean; dryRun?: bool
         process.exit(1);
     }
 
-    const version = ensureUnreleasedVersionNonInteractive(bumpType);
+    const version = ensureUnreleasedVersionNonInteractive(bumpType, options.dryRun);
 
     if (!options.dryRun) {
         const releases = loadReleasesJson();
@@ -1514,7 +1519,7 @@ async function unifiedRelease(options: { nonInteractive?: boolean; dryRun?: bool
             log(chalk.green(`✓ releases.json: ${version} marked as released (${today})`));
         }
     } else {
-        log(chalk.cyan('Dry run: releases.json was NOT modified'));
+        log(chalk.cyan(`Dry run: releases.json was NOT modified (would mark ${version} released as of today)`));
     }
 
     const baseBranch = options.since || 'main';

--- a/packages/tools/test/release-non-interactive.test.ts
+++ b/packages/tools/test/release-non-interactive.test.ts
@@ -211,21 +211,37 @@ describe('release --non-interactive (unified flow)', () => {
         expect(result.stderr).toContain('0.25.0');
     });
 
-    it('dry-run skips marking release as published', () => {
+    it('dry-run leaves releases.json byte-identical', () => {
         createFeatureBranch(repo.repoDir, 'feat/dry-run-test');
+        const releasesPath = path.join(repo.repoDir, 'releases.json');
+        const before = readFileSync(releasesPath, 'utf8');
 
         const result = run(repo.repoDir, '--non-interactive --dry-run');
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('[DRY RUN]');
+        // The prompt still names the version it would release
+        expect(result.stdout).toContain('**TASK: Release version 0.21.0**');
 
-        // The unreleased entry is created (preparation step), but NOT marked released
-        const releases = JSON.parse(readFileSync(path.join(repo.repoDir, 'releases.json'), 'utf8'));
-        const entry = releases.releases.find((r: { version: string }) => r.version === '0.21.0');
-        expect(entry).toBeDefined();
-        expect(entry.status).toBe('unreleased');
-        // latestVersion should NOT be updated
+        // `--dry-run` is documented as "Skip releases.json writes, still output prompt"
+        // (RELEASING.md) and the CLI reports the file was not modified — so it must be
+        // untouched, including the version-creation write that used to run regardless.
+        expect(readFileSync(releasesPath, 'utf8')).toBe(before);
+
+        const releases = JSON.parse(before);
+        expect(releases.releases.find((r: { version: string }) => r.version === '0.21.0')).toBeUndefined();
         expect(releases.latestVersion).toBe('0.20.0');
+    });
+
+    it('dry-run leaves the working tree clean', () => {
+        createFeatureBranch(repo.repoDir, 'feat/dry-run-clean-tree');
+
+        const result = run(repo.repoDir, '--non-interactive --dry-run');
+        expect(result.exitCode).toBe(0);
+
+        // A dry run must not require `git checkout releases.json` to recover.
+        const status = spawnSync('git', ['status', '--porcelain'], { cwd: repo.repoDir, encoding: 'utf8' });
+        expect(status.stdout.trim()).toBe('');
     });
 
     it('includes changed files in git context', () => {


### PR DESCRIPTION
### What

`pnpm run release --non-interactive --dry-run` printed:

```
Dry run: releases.json was NOT modified
```

…while modifying it.

`unifiedRelease()` called `ensureUnreleasedVersionNonInteractive()` **unconditionally, before** the
dry-run guard, so the version-creation write always ran — adding the new version entry (`status:
unreleased`, `date: TBD`) and bumping `currentDevelopment`. Only the *finalize* write was guarded.

Measured on a clean tree: a dry run produced **9 insertions** in `releases.json`, leaving the working
tree dirty and the operator to notice and run `git checkout releases.json`.

### Fix

`ensureUnreleasedVersionNonInteractive()` takes a `dryRun` flag and skips `saveReleasesJson()`,
reporting `would create ...` instead. The finalize message now also names the version it would have
released, so the two dry-run lines describe both skipped writes rather than asserting a global fact:

```
Dry run: would create unreleased version 0.29.2 in releases.json
Dry run: releases.json was NOT modified (would mark 0.29.2 released as of today)
```

The `notes` command exposes no `--dry-run`, so its call site is unaffected and keeps the default.

### An existing assertion is deliberately inverted — this is restoration, not preference

The old test asserted the write, calling it a "preparation step":

```ts
// The unreleased entry is created (preparation step), but NOT marked released
expect(entry).toBeDefined();
expect(entry.status).toBe('unreleased');
```

That assertion codified the defect. The contract for `--dry-run` is already written down in two
places, and both say it writes nothing:

1. **`RELEASING.md` § Agent / CI Workflow** documents the flag verbatim as
   `--dry-run  # Skip releases.json writes, still output prompt`
2. **The CLI itself** printed `Dry run: releases.json was NOT modified`

So the documented contract and the tool's own reported behavior agreed with each other and disagreed
with the code. Restoring the contract means the test that described the code has to change — the
inversion follows from the docs, it isn't a judgment call about what `--dry-run` *ought* to mean.

Replaced with a byte-identical check on `releases.json`, plus a new test asserting a dry run leaves
the working tree git-clean.

### Verification

- `33 passed` (was 32) — `packages/tools` jest suite
- `tsc --noEmit` clean
- Real-repo check: `releases.json` md5 identical before/after a dry run, `git status` clean

### No release entry for this

Deliberately not versioned/released:

- `packages/tools/**` is in `RELEASING.md`'s **Protected Files** list — it never syncs downstream, so
  no consumer is affected
- `RELEASING.md`: *"Don't release for: internal refactors (unless user-visible)"*
- v0.29.2 is currently in flight in #161 and unmerged; adding a 0.29.3 entry now would collide

Happy to add one if you'd rather it be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
